### PR TITLE
Add Android Firefox browser to the supported browsers

### DIFF
--- a/packages/browserslist-config/CHANGELOG.md
+++ b/packages/browserslist-config/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+- Support the last major version of Firefox on Android in browserlist config. [#193](https://github.com/Shopify/web-configs/pull/193)
 
 ## [2.2.0] - 2020-03-28
 

--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,4 +1,5 @@
 module.exports = [
+  'last 1 firefoxandroid versions',
   'last 3 chrome versions',
   'last 3 chromeandroid versions',
   'last 3 firefox versions',


### PR DESCRIPTION
Related to: https://github.com/Shopify/web/issues/27211
Related to: https://github.com/Shopify/intl-broken-experiences/issues/106

## Description
This PR adds the support for Android Firefox browser. Many of our international merchants use Firefox on Android.

## Type of change
- [x] `@shopify/browserlists-config` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
