### PR TITLE
Support script/cjs in prefer-module-scope-constants

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Add support for CommonJS in `prefer-module-scope-constants` ([#195](https://github.com/Shopify/web-configs/pull/195)).
+
 ### Changed
 
 - Updated `eslint-plugin` plugins  ([#194](https://github.com/Shopify/web-foundation/pull/194)).

--- a/packages/eslint-plugin/lib/rules/prefer-module-scope-constants.js
+++ b/packages/eslint-plugin/lib/rules/prefer-module-scope-constants.js
@@ -35,7 +35,7 @@ module.exports = {
         }
 
         const scope = context.getScope();
-        if (scope.type !== 'module') {
+        if (!['module', 'global'].includes(scope.type)) {
           context.report(
             node,
             'You must place screaming snake case at module scope. If this is not meant to be a module-scoped variable, use camelcase instead.',

--- a/packages/eslint-plugin/tests/lib/rules/prefer-module-scope-constants.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-module-scope-constants.test.js
@@ -4,7 +4,6 @@ const rule = require('../../../lib/rules/prefer-module-scope-constants');
 
 const ruleTester = new RuleTester();
 
-const parserOptions = {ecmaVersion: 6, sourceType: 'module'};
 const moduleScopeErrors = [
   {
     kind: 'VariableDeclarator',
@@ -20,46 +19,63 @@ const nonConstErrors = [
   },
 ];
 
-ruleTester.run('prefer-module-scope-constants', rule, {
-  valid: [
-    {code: 'const FOO = true;', parserOptions},
-    {code: 'const foo = true;', parserOptions},
-    {code: '{ const foo = true; }', parserOptions},
-    {code: 'const foo = true, FOO = true;', parserOptions},
-    {code: 'const {FOO} = bar', parserOptions},
-    {code: '{ const {FOO} = bar; }', parserOptions},
-    {code: 'function foo() { const {FOO} = bar; }', parserOptions},
-    {code: '{ let {FOO} = bar; }', parserOptions},
-    {code: 'function foo() { let {FOO} = bar; }', parserOptions},
-    {code: 'const [FOO] = bar', parserOptions},
-    {code: '{ const [FOO] = bar; }', parserOptions},
-    {code: 'function foo() { const [FOO] = bar; }', parserOptions},
-    {code: '{ let [FOO] = bar; }', parserOptions},
-    {code: 'function foo() { let [FOO] = bar; }', parserOptions},
-  ],
-  invalid: [
-    {code: 'let FOO = true;', parserOptions, errors: nonConstErrors},
-    {code: '{ let FOO = true; }', parserOptions, errors: nonConstErrors},
-    {
-      code: 'function foo() { let FOO = true; }',
-      parserOptions,
-      errors: nonConstErrors,
-    },
-    {
-      code: 'let foo = false, FOO = true;',
-      parserOptions,
-      errors: nonConstErrors,
-    },
-    {code: '{ const FOO = true; }', parserOptions, errors: moduleScopeErrors},
-    {
-      code: 'function foo() { const FOO = true; }',
-      parserOptions,
-      errors: moduleScopeErrors,
-    },
-    {
-      code: '{ const foo = false, FOO = true; }',
-      parserOptions,
-      errors: moduleScopeErrors,
-    },
-  ],
+const supportedParserOptions = [
+  {ecmaVersion: 6, sourceType: 'module'},
+  {ecmaVersion: 6, sourceType: 'script'},
+];
+
+supportedParserOptions.forEach((parserOptions) => {
+  ruleTester.run('prefer-module-scope-constants', rule, {
+    valid: [
+      {code: 'const FOO = true;', parserOptions},
+      {code: 'const foo = true;', parserOptions},
+      {code: '{ const foo = true; }', parserOptions},
+      {code: 'const foo = true, FOO = true;', parserOptions},
+      {code: 'const {FOO} = bar', parserOptions},
+      {code: '{ const {FOO} = bar; }', parserOptions},
+      {code: 'function foo() { const {FOO} = bar; }', parserOptions},
+      {code: '{ let {FOO} = bar; }', parserOptions},
+      {code: 'function foo() { let {FOO} = bar; }', parserOptions},
+      {code: 'const [FOO] = bar', parserOptions},
+      {code: '{ const [FOO] = bar; }', parserOptions},
+      {code: 'function foo() { const [FOO] = bar; }', parserOptions},
+      {code: '{ let [FOO] = bar; }', parserOptions},
+      {code: 'function foo() { let [FOO] = bar; }', parserOptions},
+      {
+        code: `
+          const MY_VALUE = true;
+
+          module.exports = () => {
+            console.log(MY_VALUE);
+          };
+        `,
+        parserOptions,
+      },
+    ],
+    invalid: [
+      {code: 'let FOO = true;', parserOptions, errors: nonConstErrors},
+      {code: '{ let FOO = true; }', parserOptions, errors: nonConstErrors},
+      {
+        code: 'function foo() { let FOO = true; }',
+        parserOptions,
+        errors: nonConstErrors,
+      },
+      {
+        code: 'let foo = false, FOO = true;',
+        parserOptions,
+        errors: nonConstErrors,
+      },
+      {code: '{ const FOO = true; }', parserOptions, errors: moduleScopeErrors},
+      {
+        code: 'function foo() { const FOO = true; }',
+        parserOptions,
+        errors: moduleScopeErrors,
+      },
+      {
+        code: '{ const foo = false, FOO = true; }',
+        parserOptions,
+        errors: moduleScopeErrors,
+      },
+    ],
+  });
 });


### PR DESCRIPTION
## Description

Closes https://github.com/Shopify/web-configs/issues/192

Adds commonjs / script source type support for `prefer-module-scope-constants`. Currently, only esmodules are supported.

## Type of change

- [x] `@shopify/eslint-plugin` Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
