### PR TITLE
Fix eslint-plugin eslint peerDependency

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -30,7 +30,7 @@
     "typescript": "^3.9.2"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0 | ^7.0.0"
+    "eslint": "^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.1.0",


### PR DESCRIPTION
## Description

Allow eslint-plugin to work with eslint@^7.0.0

This is a followup to https://github.com/Shopify/argo-admin-template/pull/83