### PR TITLE
Typescript naming rules

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -9,6 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Updated TypeScript naming rules to ensure type name start with a "T" and interface names don't start with an "I" ([#198](https://github.com/Shopify/web-configs/pull/198))
 - Updated `eslint-config-prettier` dependency to v3.3.0 ([#202](https://github.com/Shopify/web-configs/pull/202))
 
 ## [39.0.3] - 2020-11-17

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -77,6 +77,14 @@ module.exports = {
             format: ['PascalCase'],
             prefix: ['T'],
           },
+          {
+            selector: 'interface',
+            format: ['PascalCase'],
+            custom: {
+              regex: '^I[A-Z]',
+              match: false,
+            },
+          },
         ],
       }),
     },

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -69,6 +69,15 @@ module.exports = {
         '@shopify/typescript/prefer-singular-enums': 'error',
         // Prefer buildClientSchema for schema building.
         '@shopify/typescript/prefer-build-client-schema': 'error',
+
+        '@typescript-eslint/naming-convention': [
+          'error',
+          {
+            selector: 'typeParameter',
+            format: ['PascalCase'],
+            prefix: ['T'],
+          },
+        ],
       }),
     },
   ],


### PR DESCRIPTION
## Description

Adds two naming rules:
- Ensure all generic type names start with a `T` prefix
- Ensure all interfaces _don't_ start with an `I` prefix

I think we could do with making a decision on these two naming conventions. These make sense to me for the following reasons:

#### The `T` prefix on generics:
- TypeScript is a Microsoft language, and `T` names and prefixes are in the [official docs](https://www.typescriptlang.org/docs/handbook/generics.html)
- Other MS languages like [C#](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2?view=net-5.0) use this standard (my background when it comes to typed languages)
- Makes it easier to identify when I type is a generic, and not a concrete type filling a generic's place
- It allows people coming from other MS languages to onboard quicker to TypeScript
- I can’t find an example in the handbook where it doesn't just use T or some other letter which is slightly disheartening, but using the prefix is a visual compromise between clear generic type indication and human readable naming

#### The lack of `I` prefix on interfaces:
- Again, the TypeScript handbook does not do this, and we currently don't either (from what I've seen)
- This seems like a very _enterprise_ rule that might be a little antiquated
- This probably doesn't need as much selling, but having a linting rule that explicitly complains when others do this will help make code consistent

## Type of change

- [x] `@shopify/esling-plugin` Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
