### PR TITLE
[@shopify/babel-preset] Bump core-js^3.0.0

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-<!-- ## Unreleased -->
+## [Unreleased]
+
+- Changed the default `corejs` version for `node` and `web` presets (default = `3`) [[#199](https://github.com/Shopify/web-configs/pull/199)]
+- Changed the default `useBuiltIns` option for `node` and `web` presets (default = `usage`) [[#199](https://github.com/Shopify/web-configs/pull/199)]
 
 ## [23.1.1] - 2020-08-26
 

--- a/packages/babel-preset/node.js
+++ b/packages/babel-preset/node.js
@@ -4,9 +4,9 @@ module.exports = function shopifyNodePreset(_api, options = {}) {
   const {
     version = 'current',
     modules = 'commonjs',
-    corejs = 2,
+    corejs = 3,
     debug = false,
-    useBuiltIns = 'entry',
+    useBuiltIns = 'usage',
     typescript = false,
   } = options;
 

--- a/packages/babel-preset/web.js
+++ b/packages/babel-preset/web.js
@@ -3,10 +3,10 @@ const nonStandardPlugins = require('./non-standard-plugins');
 module.exports = function shopifyWebPreset(_api, options = {}) {
   const {
     modules = 'commonjs',
-    corejs = 2,
+    corejs = 3,
     debug = false,
     browsers,
-    useBuiltIns = 'entry',
+    useBuiltIns = 'usage',
     typescript = false,
   } = options;
 


### PR DESCRIPTION
## Description
Changed the default version of core-js.

[According to the doc](https://github.com/zloirock/core-js#babelpreset-env), we should specify the minor core-js version.
>Warning! Recommended to specify used minor core-js version, like corejs: '3.8', instead of corejs: 3, since with corejs: 3 will not be injected modules which were added in minor core-js releases.

I will redefine the core-js version to use the minor version in sewing-kit.

## Type of change

- [x] `@shopify/babel-preset` Major: Breaking change expected

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
