### PR TITLE
Add the ability to disable transform-react-custom-elements

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
-## Unreleased
+<!-- ## Unreleased -->
 
 ### Added
 

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -10,7 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Added the ability to disable `@babel/plugin-transform-react-constant-elements` [[#155](https://github.com/Shopify/web-foundation/pull/155)]
+- Added the ability to disable `@babel/plugin-transform-react-constant-elements` [[#205](https://github.com/Shopify/web-foundation/pull/205)]
 
 ## [23.1.1] - 2020-08-26
 

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added the ability to disable `@babel/plugin-transform-react-constant-elements` [[#155](https://github.com/Shopify/web-foundation/pull/155)]
 
 ## [23.1.1] - 2020-08-26
 

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -96,6 +96,7 @@ This packages comes with several different presets for you to use, depending on 
   This preset accepts an options object.
   - `pragma` : Replace the function used when compiling JSX expressions. Defaults to `React.createElement`.
   - `pragmaFrag`: Replace the function used when compiling JSX fragment expressions. Defaults to `React.Fragment`.
+  - `transformReactConstantElements`: Adds the `@babel/plugin-transform-react-constant-elements` plugin for production environments. Defaults to `true`.
 
   ```json
   {

--- a/packages/babel-preset/react.js
+++ b/packages/babel-preset/react.js
@@ -3,9 +3,10 @@ module.exports = function shopifyReactPreset(api, options = {}) {
 
   const pragma = options.pragma || 'React.createElement';
   const pragmaFrag = options.pragmaFrag || 'React.Fragment';
+  const transformReactConstantElements = options.transformReactConstantElements || true;
   const plugins = [];
 
-  if (env === 'production') {
+  if (env === 'production' && transformReactConstantElements) {
     plugins.push(
       // Hoist constant JSX elements to the top of their scope, which can
       // result in faster reconciliation

--- a/packages/babel-preset/react.js
+++ b/packages/babel-preset/react.js
@@ -3,7 +3,8 @@ module.exports = function shopifyReactPreset(api, options = {}) {
 
   const pragma = options.pragma || 'React.createElement';
   const pragmaFrag = options.pragmaFrag || 'React.Fragment';
-  const transformReactConstantElements = options.transformReactConstantElements || true;
+  const transformReactConstantElements =
+    options.transformReactConstantElements || true;
   const plugins = [];
 
   if (env === 'production' && transformReactConstantElements) {


### PR DESCRIPTION
## Description
When there is a component that is used before it is defined the react import doesn't get minified causing reference error.
This PR allows the `transform-react-custom-elements` to be disabled.

See this bug report for more details: https://github.com/babel/babel/issues/10878

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
