### PR TITLE
Add babel transform runtime

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -11,6 +11,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Updated `@babel/*` presets and plugins to version `7.12` [[#207](https://github.com/Shopify/web-foundation/pull/207)]
 
+### Added
+
+- Added the ability to add `@babel/plugin-transform-runtime` [[#206](https://github.com/Shopify/web-configs/pull/206)]
+
 ## [23.2.0] - 2021-02-09
 
 ### Added

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -76,6 +76,8 @@ This packages comes with several different presets for you to use, depending on 
 
     - `useBuiltIns`, a string that is passed to the [`useBuiltIns` option of `@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env#usebuiltins)
 
+    - `transformRuntime`, a boolean (defaults to `false` and requires `typescript` to be `true`) to add the [`@babel/plugin-transform-runtime` plugin](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime).
+
 - `@shopify/babel-preset/node`: This preset transpiles features to a specified version of Node, defaulting to the currently active version. It accepts an options object. The `modules`, `typescript`, `inlineEnv`,`debug`, `corejs` and `useBuiltIns` options do the same thing they do in `@shopify/babel-preset/web`, detailed above. You can also pass a version of Node to target during transpilation using the `version` option:
 
   ```json

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -78,6 +78,8 @@ This packages comes with several different presets for you to use, depending on 
 
     - `transformRuntime`, a boolean (defaults to `false` and requires `typescript` to be `true`) to add the [`@babel/plugin-transform-runtime` plugin](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-runtime).
 
+    - `transformRuntimeOptions`, allows the [`@babel/plugin-transform-runtime` plugin](https://babeljs.io/docs/en/babel-plugin-transform-runtime#options) to be configured.
+
 - `@shopify/babel-preset/node`: This preset transpiles features to a specified version of Node, defaulting to the currently active version. It accepts an options object. The `modules`, `typescript`, `inlineEnv`,`debug`, `corejs` and `useBuiltIns` options do the same thing they do in `@shopify/babel-preset/web`, detailed above. You can also pass a version of Node to target during transpilation using the `version` option:
 
   ```json

--- a/packages/babel-preset/non-standard-plugins.js
+++ b/packages/babel-preset/non-standard-plugins.js
@@ -3,6 +3,13 @@ module.exports = function shopifyNonStandardPlugins(options = {}) {
     inlineEnv = false,
     typescript = false,
     transformRuntime = false,
+    transformRuntimeOptions = {
+      useESModules: false,
+      corejs: false,
+      regenerator: true,
+      helpers: true,
+      absoluteRuntime: false,
+    },
   } = options;
 
   const plugins = [require.resolve('@babel/plugin-syntax-dynamic-import')];
@@ -51,6 +58,7 @@ module.exports = function shopifyNonStandardPlugins(options = {}) {
       plugins.push([
         '@babel/plugin-transform-runtime',
         {
+          ...transformRuntimeOptions,
           version: require('@babel/plugin-transform-runtime/package.json')
             .version,
         },

--- a/packages/babel-preset/non-standard-plugins.js
+++ b/packages/babel-preset/non-standard-plugins.js
@@ -1,5 +1,9 @@
 module.exports = function shopifyNonStandardPlugins(options = {}) {
-  const {inlineEnv = false, typescript = false} = options;
+  const {
+    inlineEnv = false,
+    typescript = false,
+    transformRuntime = false,
+  } = options;
 
   const plugins = [require.resolve('@babel/plugin-syntax-dynamic-import')];
 
@@ -38,6 +42,20 @@ module.exports = function shopifyNonStandardPlugins(options = {}) {
         {loose: true},
       ],
     );
+
+    if (transformRuntime) {
+      // When compiling TypeScript with only babel-loader, extra helpers are
+      // inlined in each source module. This normally adds some bulks to files,
+      // but `transform-runtime` converts these blocks into common helper imports
+      // that webpack can collate into shared assets.
+      plugins.push([
+        '@babel/plugin-transform-runtime',
+        {
+          version: require('@babel/plugin-transform-runtime/package.json')
+            .version,
+        },
+      ]);
+    }
   } else {
     plugins.push(require.resolve('@babel/plugin-proposal-class-properties'));
   }

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -28,6 +28,7 @@
     "@babel/plugin-proposal-optional-chaining": "^7.12.13",
     "@babel/plugin-transform-modules-commonjs": "^7.12.13",
     "@babel/plugin-transform-react-constant-elements": "^7.12.13",
+    "@babel/plugin-transform-runtime": "^7.12.15",
     "@babel/preset-env": "^7.12.13",
     "@babel/preset-react": "^7.12.13",
     "@babel/preset-typescript": "^7.12.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -721,6 +721,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
+"@babel/plugin-transform-runtime@^7.12.15":
+  version "7.12.15"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.15.tgz#4337b2507288007c2b197059301aa0af8d90c085"
+  integrity sha512-OwptMSRnRWJo+tJ9v9wgAf72ydXWfYSXWhnQjZing8nGZSDFqU1MBleKM3+DriKkcbv7RagA8gVeB0A1PNlNow==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.12.13"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz#db755732b70c539d504c6390d9ce90fe64aff7ad"
@@ -8266,7 +8275,7 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
## Description
This PR adds the ability to enable `transformRuntime` to add the babel plugin `@babel/plugin-transform-runtime`.

> When compiling TypeScript with only babel-loader, extra helpers are inlined in each source module. This normally adds some bulks to files, but `transform-runtime` converts these blocks into common helper imports that webpack can collate into shared assets.

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [X] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
