### PR TITLE
Much better way of setting options

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
+
 ### Changed
 
 - Improved how options are defined in `@shopify/babel-preset/react` [[#209](https://github.com/Shopify/web-configs/pull/209)]

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
+### Changed
+
+- Improved how options are defined in `@shopify/babel-preset/react` [[#209](https://github.com/Shopify/web-configs/pull/209)]
 
 ## [23.3.1] - 2021-02-10
 

--- a/packages/babel-preset/react.js
+++ b/packages/babel-preset/react.js
@@ -1,10 +1,12 @@
 module.exports = function shopifyReactPreset(api, options = {}) {
   const env = api.env();
 
-  const pragma = options.pragma || 'React.createElement';
-  const pragmaFrag = options.pragmaFrag || 'React.Fragment';
-  const transformReactConstantElements =
-    options.transformReactConstantElements ?? true;
+  const {
+    pragma = 'React.createElement',
+    pragmaFrag = 'React.Fragment',
+    transformReactConstantElements = true,
+  } = options;
+
   const plugins = [];
 
   if (env === 'production' && transformReactConstantElements) {

--- a/packages/babel-preset/react.js
+++ b/packages/babel-preset/react.js
@@ -1,11 +1,12 @@
-module.exports = function shopifyReactPreset(api, options = {}) {
-  const env = api.env();
-
-  const {
+module.exports = function shopifyReactPreset(
+  api,
+  {
     pragma = 'React.createElement',
     pragmaFrag = 'React.Fragment',
     transformReactConstantElements = true,
-  } = options;
+  } = {},
+) {
+  const env = api.env();
 
   const plugins = [];
 


### PR DESCRIPTION
## Description
This PR sets options in `babel-preset/react` the same way `babel-preset/web` does to be more consistent.

I 🎩 ed this on another repo.
<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [X] `@shopify/babel-preset` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
