### PR TITLE
Fix the all.js test for the eslint-plugin

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Updated `eslint-plugin` test to prepare for `eslint@7` upgrade ([#211](https://github.com/Shopify/web-configs/pull/211))
+
 ## [39.0.4] - 2022-01-13
 
 ### Changed

--- a/packages/eslint-plugin/tests/fixtures/all/app/graphql/Query.graphql
+++ b/packages/eslint-plugin/tests/fixtures/all/app/graphql/Query.graphql
@@ -1,5 +1,6 @@
-query LintErrorFooQuery {
+query AllTestQuery {
   foo {
-    DOES_NOT_EXIST
+    id
+    bar
   }
 }

--- a/packages/eslint-plugin/tests/lib/config/all.test.js
+++ b/packages/eslint-plugin/tests/lib/config/all.test.js
@@ -4,7 +4,9 @@ describe('config', () => {
   it('has valid plugins and requires', () => {
     expect(
       execESLint(
-        `--ext .js,.graphql --ignore-pattern "**/all/build/*" --config ${fixtureFile('all/.eslintrc.js')} ${fixtureFile('all')}`,
+        `--ext .js,.graphql --ignore-pattern "**/all/build/*" --config ${fixtureFile(
+          'all/.eslintrc.js',
+        )} ${fixtureFile('all')}`,
       ),
     ).toBe('');
   }, 8000);

--- a/packages/eslint-plugin/tests/lib/config/all.test.js
+++ b/packages/eslint-plugin/tests/lib/config/all.test.js
@@ -4,7 +4,7 @@ describe('config', () => {
   it('has valid plugins and requires', () => {
     expect(
       execESLint(
-        `--config ${fixtureFile('all/.eslintrc.js')} ${fixtureFile('all')}`,
+        `--ext .js,.graphql --ignore-pattern "**/all/build/*" --config ${fixtureFile('all/.eslintrc.js')} ${fixtureFile('all')}`,
       ),
     ).toBe('');
   }, 8000);


### PR DESCRIPTION
## Description
The `all.js` test works because it ignored the `.graphql` files included in the fixture and didn't apply the `.graphql` rules.
This PR updates the fixture and the `all.test.js` execution to include the graphql files.

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [X] `@shopify/eslint-plugin` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
