### PR TITLE
Update @typescript-eslint/array-type to be compatible with @typescrip…

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Updated `eslint-plugin` to fix incompatibility between `@typescript-eslint/array-type` and `@typescript-eslint/ban-types` ([#212](https://github.com/Shopify/web-configs/pull/212))
+- Fix incompatibility between `@typescript-eslint/array-type` and `@typescript-eslint/ban-types` ([#212](https://github.com/Shopify/web-configs/pull/212))
 
 ## [40.0.0] - 2021-02-12
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Updated `eslint-plugin` to fix incompatibility between `@typescript-eslint/array-type` and `@typescript-eslint/ban-types` ([#212](https://github.com/Shopify/web-configs/pull/212))
+
 ## [40.0.0] - 2021-02-12
 
 ### Changed

--- a/packages/eslint-plugin/lib/config/rules/typescript.js
+++ b/packages/eslint-plugin/lib/config/rules/typescript.js
@@ -88,11 +88,11 @@ module.exports = {
   ],
   // Disallow the declaration of empty interfaces. (no-empty-interface from TSLint)
   '@typescript-eslint/no-empty-interface': 'off',
-  // Requires using either T[] or Array<T> for arrays (array-type)
+  // Requires using either T[] for arrays (array-type)
   '@typescript-eslint/array-type': [
     'error',
     {
-      default: 'array-simple',
+      default: 'array',
       readonly: 'generic',
     },
   ],


### PR DESCRIPTION
## Description
Update @typescript-eslint/array-type to be compatible with @typescript-eslint/ban-types

`array-simple` causes this error:
```
error: Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead (@typescript-eslint/array-type) at packages/sewing-kit/src/tools/webpack/playground/index.ts:59:21:
  57 |     : playgroundForWorkspace();
  58 |
> 59 |   const filesToAdd: Promise<void>[] = [];
     |                     ^
  60 |
  61 |   if (force || !(await pathExists(playgroundFile))) {
  62 |     filesToAdd.push(writeFile(playgroundFile, format(playgroundContent)));
  ```
  
When the type gets updated to `Array<Promise<void>>` then the `@typescript-eslint/ban-types` is tripped.

I tested this against `sewing-kit`

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] `@shopify/eslint-plugin` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
