### PR TITLE
include jest-formatting rules in @shopify/eslint-plugin

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Include jest formatting in `@shopify/eslint-plugin` ruleset ([#213](https://github.com/Shopify/web-configs/pull/213))
+
 ## [40.0.1] - 2021-02-12
 
 ### Changed

--- a/packages/eslint-plugin/lib/config/jest.js
+++ b/packages/eslint-plugin/lib/config/jest.js
@@ -12,7 +12,7 @@ module.exports = {
 
   plugins: ['jest', 'jest-formatting', '@shopify'],
 
-  rules: merge(require('./rules/jest'), {
+  rules: merge(require('./rules/jest'), require('./rules/jest-formatting'), {
     'jest/valid-title': [
       'error',
       {


### PR DESCRIPTION
## Description

jest-formatting rules were added in https://github.com/Shopify/web-configs/pull/178 but they were never included in the default ruleset applied in `config/jest.js`. This PR includes the rules defined in that earlier PR in the ruleset applied when consumers extend `plugin:@shopify/jest` in their `eslintrc`

## Type of change
- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] `@shopify/eslint-plugin` Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
