### PR TITLE
 TS Configs: Enable isolatedModules

### DIFF
--- a/packages/typescript-configs/CHANGELOG.md
+++ b/packages/typescript-configs/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Breaking Change
+
+Set `isolatedModules` to be true by default. Sewing-kit is moving away from a `tsc` based compilation process, towards using babel/esbuild only single file transpilation. Prepare consumers for this change by making type-checking identify code that can be problematic with single-file transpilers. [[#214](https://github.com/Shopify/web-configs/pull/214)]
 
 ## [3.0.0] - 2020-06-04
 

--- a/packages/typescript-configs/base.json
+++ b/packages/typescript-configs/base.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "esModuleInterop": true,
+    "isolatedModules": true,
     "experimentalDecorators": true,
     "lib": ["dom", "es2018", "esnext.asynciterable"],
     "moduleResolution": "node",


### PR DESCRIPTION
## Description

sewing-kit is moving towards using single-file transpilation instead of
using tsc for TypeScript transpilation. Enabling isolatedModules will
help users identify patterns that are problematic for single-file
transpilers such as babel, and esbuild.

## Type of change

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [x] typescript-configs Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
