### PR TITLE
[Eslint] Adding in jsx-a11y/autocomplete-valid rule to config

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## [Unreleased] -->
 
+### Changed
+
+- Added `jsx-a11y/autocomplete-valid` rule for `eslint-plugin`([217](https://github.com/Shopify/web-configs/pull/218))
+
 ## [40.1.0] - 2021-02-24
 
 ### Changed

--- a/packages/eslint-plugin/lib/config/rules/jsx-a11y.js
+++ b/packages/eslint-plugin/lib/config/rules/jsx-a11y.js
@@ -71,4 +71,11 @@ module.exports = {
   'jsx-a11y/scope': 'error',
   // Enforce tabIndex value is not greater than zero.
   'jsx-a11y/tabindex-no-positive': 'error',
+  // Ensure the autocomplete attribute is correct and suitable for the form field it is used with.
+  'jsx-a11y/autocomplete-valid': [
+    'error',
+    {
+      inputComponents: ['TextField', 'Select'],
+    },
+  ],
 };


### PR DESCRIPTION
## Description

Adds jsx-a11y/autocomplete-valid rule to eslint config as part of [Autocomplete Project](https://vault.shopify.io/projects/17459).

Specifies 2 custom Polaris input types: `TextField`, `Select`

Resolves [issues/217](https://github.com/Shopify/web-configs/issues/217)

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] `eslint-plugin` Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
