### PR TITLE
Fix a conflict between Prettier and rules `*/object-curly-spacing`

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Added `jsx-a11y/autocomplete-valid` rule for `eslint-plugin`([217](https://github.com/Shopify/web-configs/pull/218))
 - Updated `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` to version `4.20.0` [[#223](https://github.com/Shopify/web-foundation/pull/223)]
+- Fixed a conflict between Prettier and rules `*/object-curly-spacing` ([227](https://github.com/Shopify/web-configs/pull/227))
 
 ## [40.1.0] - 2021-02-24
 

--- a/packages/eslint-plugin/lib/config/prettier.js
+++ b/packages/eslint-plugin/lib/config/prettier.js
@@ -10,6 +10,7 @@ module.exports = {
     '@shopify/class-property-semi': 'off',
     '@shopify/binary-assignment-parens': 'off',
     'babel/semi': 'off',
+    'babel/object-curly-spacing': 'off',
     'prefer-arrow-callback': 'off',
     'arrow-body-style': 'off',
 

--- a/packages/eslint-plugin/lib/config/rules/prettier-typescript.js
+++ b/packages/eslint-plugin/lib/config/rules/prettier-typescript.js
@@ -8,4 +8,5 @@ module.exports = {
   '@typescript-eslint/no-extra-parens': 'off',
   '@typescript-eslint/semi': 'off',
   '@typescript-eslint/type-annotation-spacing': 'off',
+  '@typescript-eslint/object-curly-spacing': 'off',
 };


### PR DESCRIPTION
## Description

This PR fixes a rule conflict between Prettier and `@typescript-eslint/object-curly-spacing` and `babel/object-curly-spacing`.

Closes #226 

## Type of change

- [x] @shopify/eslint-plugin Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
