### PR TITLE
Add option for enabling plugins for dynamic imports on node webpack

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Added
+
+- Add the `nodeWebpack` option to the `common` babel-preset [[#236](https://github.com/Shopify/web-foundation/pull/236)]
+
 ## [23.5.1] - 2021-04-20
 
 ### Changed

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -225,3 +225,8 @@ This option when `true` will enable the `@babel/plugin-transform-react-constant-
 
 [Documentation](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements)
     
+#### `nodeWebpack`
+
+`boolean`, defaults to `false`.
+
+This option when `true` will enable the `'@babel/plugin-proposal-dynamic-import'` and the `'@babel/plugin-transform-modules-commonjs'` plugins.

--- a/packages/babel-preset/common.js
+++ b/packages/babel-preset/common.js
@@ -27,6 +27,7 @@ module.exports = function shopifyCommonPreset(
       useBuiltIns: true,
     },
     transformReactConstantElements = false,
+    nodeWebpack = false,
   } = {},
 ) {
   const env = api.env();
@@ -99,6 +100,11 @@ module.exports = function shopifyCommonPreset(
     // result in faster reconciliation
     includeTransformReactConstantElements &&
       require.resolve('@babel/plugin-transform-react-constant-elements'),
+    // @babel/plugin-proposal-dynamic-import and @babel/plugin-transform-modules-commonjs
+    // must be enabled together when compiling for node and webpack that contains
+    // dynamic imports
+    nodeWebpack && require.resolve('@babel/plugin-proposal-dynamic-import'),
+    nodeWebpack && require.resolve('@babel/plugin-transform-modules-commonjs'),
   ].filter(Boolean);
 
   return {presets, plugins};


### PR DESCRIPTION
## Description
This PR adds a new options to the common preset. `nodeWebpack` which enables the `'@babel/plugin-proposal-dynamic-import'` and the `'@babel/plugin-transform-modules-commonjs'` plugins.

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] `@shopify/babel-preset`<!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
