### PR TITLE
Remove non-existent rule and bump stylelint peer dep

### DIFF
--- a/packages/stylelint-plugin/CHANGELOG.md
+++ b/packages/stylelint-plugin/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Changed
+
+- Remove `no-invalid-position-at-import-rule` rule as it is not in a currently released version of stylelint [[#237](https://github.com/Shopify/web-configs/pull/237)]
+- Update peer dependency to `>=13.12.0` [[#237](https://github.com/Shopify/web-configs/pull/237)]
 
 ## [10.1.0] - 2021-03-10
 
@@ -350,7 +355,6 @@ property: <top> <right> <bottom> <left>
 
 * Initial release
 
-[Unreleased]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.4.0...HEAD
 [7.3.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.3.0...v7.4.0
 [7.3.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.2.1...v7.3.0
 [7.2.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.2.0...v7.2.1

--- a/packages/stylelint-plugin/config/general.js
+++ b/packages/stylelint-plugin/config/general.js
@@ -23,6 +23,4 @@ module.exports = {
   'no-missing-end-of-source-newline': true,
   // Disallow animation names that do not correspond to a @keyframes declaration.
   'no-unknown-animations': true,
-  // Disallow invalid position `@import` rules within a stylesheet.
-  'no-invalid-position-at-import-rule': true,
 };

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -35,6 +35,6 @@
     "stylelint": "^13.12.0"
   },
   "peerDependencies": {
-    "stylelint": ">=13.7.0"
+    "stylelint": ">=13.12.0"
   }
 }


### PR DESCRIPTION
## Description

https://github.com/Shopify/web-configs/pull/224 added some new stylelint rules. However `no-invalid-position-at-import-rule` isn't actually released yet per [stylelint's changelog](https://github.com/stylelint/stylelint/blob/master/CHANGELOG.md), and thus using the config results in an "Unknown rule" error.

Also bump the stylelint peer dependency to ensure consumers use a stylelint version that has the other rules that we specify.

## Type of change

- [x] stylelint-config Patch: Bug (non-breaking change which fixes an issue)


## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
