### PR TITLE
Remove [] from changlogs

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -7,13 +7,13 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
-## [23.5.1] - 2021-04-20
+## 23.5.1 - 2021-04-20
 
 ### Changed
 
 - Updated `@babel/core`, `@babel/runtime`, and fixes `@shopify/babel-preset` react settings [[#235](https://github.com/Shopify/web-foundation/pull/235)]
 
-## [23.5.0] - 2021-04-20
+## 23.5.0 - 2021-04-20
 
 ### Added
 
@@ -23,31 +23,31 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Updated `@babel/*` presets and plugins to version `7.13.x` [[#231](https://github.com/Shopify/web-foundation/pull/231)]
 
-## [23.4.1] - 2021-04-16
+## 23.4.1 - 2021-04-16
 
 ### Changed
 
 - Updated `@babel/*` presets and plugins to version `7.13.x` [[#222](https://github.com/Shopify/web-foundation/pull/222)]
 
-## [23.4.0] - 2021-03-10
+## 23.4.0 - 2021-03-10
 
 ### Changed
 
 - Updated `@babel/*` presets and plugins to version `7.13` [[#219](https://github.com/Shopify/web-foundation/pull/219)]
 
-## [23.3.2] - 2021-02-11
+## 23.3.2 - 2021-02-11
 
 ### Changed
 
 - Improved how options are defined in `@shopify/babel-preset/react` [[#209](https://github.com/Shopify/web-configs/pull/209)]
 
-## [23.3.1] - 2021-02-10
+## 23.3.1 - 2021-02-10
 
 ### Changed
 
 - Bugfix for disabling `transformReactConstantElements` [[#208](https://github.com/Shopify/web-configs/pull/208)]
 
-## [23.3.0] - 2021-02-10
+## 23.3.0 - 2021-02-10
 
 ### Changed
 
@@ -57,29 +57,29 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Added the ability to add `@babel/plugin-transform-runtime` [[#206](https://github.com/Shopify/web-configs/pull/206)]
 
-## [23.2.0] - 2021-02-09
+## 23.2.0 - 2021-02-09
 
 ### Added
 
 - Added the ability to disable `@babel/plugin-transform-react-constant-elements` [[#205](https://github.com/Shopify/web-foundation/pull/205)]
 
-## [23.1.1] - 2020-08-26
+## 23.1.1 - 2020-08-26
 
 - Update `@babel/preset-env` and other babel packages to 7.10.4 and enable preset-env's [`bugfixes`](https://babeljs.io/docs/en/babel-preset-env#bugfixes) option [[#172](https://github.com/Shopify/web-foundation/pull/172)]
 
-## [23.1.0] - 2020-05-12
+## 23.1.0 - 2020-05-12
 
 ### Changed
 
 - Update `@babel/core`, `@babel/preset-env`, `@babel/plugin-transform-modules-commonjs` to `7.9.6` [[#155](https://github.com/Shopify/web-foundation/pull/155)]
 
-## [23.0.0] - 2020-04-23
+## 23.0.0 - 2020-04-23
 
 ### Changed
 
 - Remove `react-hot-loader` since `react-fast-refresh` is now used in sewing-kit [[#145](https://github.com/Shopify/web-foundation/pull/145)]
 
-## [22.0.0] - 2020-03-28
+## 22.0.0 - 2020-03-28
 
 🚨Package rename
 
@@ -101,7 +101,7 @@ module.exports = {
 };
 ```
 
-## [21.0.0]
+## 21.0.0
 
 ### Added
 
@@ -111,55 +111,55 @@ module.exports = {
 
 - Updated `@babel/core`, `@babel/preset-env`, presets, and plugins updated to the latest `7.7.x` versions [[#47](https://github.com/Shopify/babel-preset-shopify/pull/47)]
 
-## [20.1.0] - 2019-09-24
+## 20.1.0 - 2019-09-24
 
 - Pass `browsers` web preset config string directly into babel-preset-env's targets option, so that if it is unset we shall read honor browserslist config in package.json / .browserslistrc
 
-## [20.0.0] - 2019-06-03
+## 20.0.0 - 2019-06-03
 
 - Add `babel-plugin-dynamic-import-node` to the node preset. This was originally added in 19.1.0 then reverted in 19.1.1 as it was a breaking change in some circumstances
 
-## [19.1.1] - 2019-06-03
+## 19.1.1 - 2019-06-03
 
 - Revert Adding `babel-plugin-dynamic-import-node` to the node preset as this may be a breaking change in some circumstances
 
-## [19.1.0] - 2019-05-29
+## 19.1.0 - 2019-05-29
 
 - Added `typescript` option to node and web presets to allow babel to read typescript files when set to true.
 - Added `babel-plugin-dynamic-import-node` to the node preset
 - Removed `@babel/plugin-proposal-optional-catch-binding` because it is already handled by `@babel/preset-env` if you specify an environment where it is needed.
 
-## [19.0.1] - 2019-05-23
+## 19.0.1 - 2019-05-23
 
 - Added `@babel/plugin-proposal-optional-catch-binding` to `node` and `web` presets
 
-## [19.0.0] - 2019-05-06
+## 19.0.0 - 2019-05-06
 
 - Switched the default `useBuiltIns` option back to `entry`, since it has a smaller bundle impact on large applications
 
-## [18.1.1] - 2019-05-03
+## 18.1.1 - 2019-05-03
 
 - `web` preset now accepts a `useBuiltIn` value (default = `usage`)
 
-## [18.1.0] - 2019-04-22
+## 18.1.0 - 2019-04-22
 
 ### Added
 
 - `node` and `web` presets now accept a `corejs` option (default = `2`)
 
-## [18.0.0] - 2019-03-19
+## 18.0.0 - 2019-03-19
 
 ### Changed
 
 - `node` and `web` presets now use `useBuiltIns: 'usage'` for including `corejs` polyfills.
 
-## [17.0.1] - 2019-01-09
+## 17.0.1 - 2019-01-09
 
 ### Fixed
 
 - Honor the `envName` defined in your babel config.
 
-## [17.0.0] - 2019-01-03
+## 17.0.0 - 2019-01-03
 
 ### Changed
 
@@ -175,13 +175,13 @@ module.exports = {
 
 - The `shopify/react` preset now accepts a `pragmaFrag` option for specifying the component to use in JSX fragment expressions.
 
-## [16.7.0] - 2018-12-18
+## 16.7.0 - 2018-12-18
 
 ### Changed
 
 - Removed `babel-plugin-transform-react-pure-to-component`.
 
-## [16.6.0] - 2018-10-11
+## 16.6.0 - 2018-10-11
 
 ### Changed
 
@@ -195,49 +195,49 @@ module.exports = {
 
 - Switch from Circle CI to Travis.
 
-## [16.5.0] - 2018-05-01
+## 16.5.0 - 2018-05-01
 
 ### Chore
 
 - Added `publishConfig` to fix deployments.
 
-## [16.4.0] - 2018-05-01
+## 16.4.0 - 2018-05-01
 
 ### Added
 
 - `shopify/react` preset now accepts an additional option, `pragma`. Defaults to `React.createElement`.
 
-## [16.3.0] - 2018-03-14
+## 16.3.0 - 2018-03-14
 
 ### Added
 
 - `shopify/web` and `shopify/node` now accept an additional option, `debug`. When passed, this enables `babel-preset-env`'s debugging to show why transforms are being included in a project. Defaults to `false` (current behaviour).
 
-## [16.2.0] - 2017-08-23
+## 16.2.0 - 2017-08-23
 
 ### Added
 
 - Added `babel-plugin-syntax-dynamic-import` to the web config.
 
-## [16.1.0] - 2017-06-08
+## 16.1.0 - 2017-06-08
 
 ### Added
 
 - Added a Babel plugin to remove `testID` props in non-test environments.
 
-## [16.0.2] - 2017-02-18
+## 16.0.2 - 2017-02-18
 
 ### Changed
 
 - Integrated bugfix from most recent version of `babel-plugin-transform-react-pure-to-component`.
 
-## [16.0.1] - 2017-02-17
+## 16.0.1 - 2017-02-17
 
 ### Fixed
 
 - `shopify/web` and `shopify/node` now correctly default the `modules` option to `'commonjs'` instead of `true`.
 
-## [16.0.0] - 2017-02-07
+## 16.0.0 - 2017-02-07
 
 ### Added
 
@@ -251,6 +251,6 @@ module.exports = {
 - `shopify/web` and `shopify/node` presets now use [`babel-preset-env`](https://github.com/babel/babel-preset-env) to transpile only the features needed for the target environment.
 - Updated all versions of dependend-on plugins and presets.
 
-## [15.0.1]
+## 15.0.1
 
 - Initial move from combined `javascript` repo.

--- a/packages/browserslist-config/CHANGELOG.md
+++ b/packages/browserslist-config/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+<!-- ## Unreleased -->
 
-## [2.2.4] - 2020-11-03
+## 2.2.4 - 2020-11-03
 
 - Support the last major version of Firefox on Android in browserlist config. [#193](https://github.com/Shopify/web-configs/pull/193)
 
-## [2.2.0] - 2020-03-28
+## 2.2.0 - 2020-03-28
 
 - Support now the last 3 major version of Edge

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,34 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+<!-- ## Unreleased -->
 
-## [40.2.1] - 2021-04-16
+## 40.2.1 - 2021-04-16
 
 ### Changed
 
 - Fixed a conflict between Prettier and rules `*/object-curly-spacing` ([227](https://github.com/Shopify/web-configs/pull/227))
 
-## [40.2.0] - 2021-04-16
+## 40.2.0 - 2021-04-16
 
 ### Changed
 
 - Added `jsx-a11y/autocomplete-valid` rule for `eslint-plugin`([217](https://github.com/Shopify/web-configs/pull/218))
 - Updated `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` to version `4.20.0` [[#223](https://github.com/Shopify/web-foundation/pull/223)]
 
-## [40.1.0] - 2021-02-24
+## 40.1.0 - 2021-02-24
 
 ### Changed
 
 - Include jest formatting in `@shopify/eslint-plugin` ruleset ([#213](https://github.com/Shopify/web-configs/pull/213))
 
-## [40.0.1] - 2021-02-12
+## 40.0.1 - 2021-02-12
 
 ### Changed
 
 - Fix incompatibility between `@typescript-eslint/array-type` and `@typescript-eslint/ban-types` ([#212](https://github.com/Shopify/web-configs/pull/212))
 
-## [40.0.0] - 2021-02-12
+## 40.0.0 - 2021-02-12
 
 ### Changed
 
@@ -54,20 +54,20 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 | `@typescript-eslint/parser`               | `4.1.0`     | `4.15.0`    |
 | `change-case`                             | `4.1.0`     | `4.1.2`     |
 
-## [39.0.4] - 2021-01-13
+## 39.0.4 - 2021-01-13
 
 ### Changed
 
 - Updated TypeScript naming rules to ensure type name start with a "T" and interface names don't start with an "I" ([#198](https://github.com/Shopify/web-configs/pull/198))
 - Updated `eslint-config-prettier` dependency to v3.3.0 ([#202](https://github.com/Shopify/web-configs/pull/202))
 
-## [39.0.3] - 2020-11-17
+## 39.0.3 - 2020-11-17
 
 ### Fixed
 
 - Fixed a syntax error in `peerDependencies` to allow eslint@^7.0.0 ([#196](https://github.com/Shopify/web-configs/pull/196)).
 
-## [39.0.2] - 2020-11-03
+## 39.0.2 - 2020-11-03
 
 ### Fixed
 
@@ -87,7 +87,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 | `eslint-plugin-react-hooks`        | `4.1.1`     | `4.1.2`     |
 
 
-## [39.0.0] - 2020-09-17
+## 39.0.0 - 2020-09-17
 
 ### Breaking Change
 
@@ -110,7 +110,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 | `eslint-plugin-sort-class-members` | `1.7.0`     | `1.8.0`     |
 
 
-## [38.0.0]
+## 38.0.0
 
 ### Added
 
@@ -125,7 +125,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - Removal of `@typescript-eslint/ban-ts-ignore` for `@typescript-eslint/ban-ts-comment`. Please update your ignore statements.
 
 
-## [37.0.0] - 2020-05-19
+## 37.0.0 - 2020-05-19
 
 ### Added
 
@@ -156,15 +156,15 @@ Facebook improved the `eslint-plugin-react-hooks` plugin. We may have to update 
 | `merge`                            | `1.2.1`     | `1.2.1`     |
 | `pkg-dir`                          | `4.2.0`     | `4.2.0`     |
 
-## [36.1.0] - 2020-05-05
+## 36.1.0 - 2020-05-05
 
 - adding `allow` and `maxDepth` options to `strict-component-boundaries` rule. ([#150](https://github.com/Shopify/web-foundation/pull/150))
 
-## [36.0.1] - 2020-03-28
+## 36.0.1 - 2020-03-28
 
 - Fix an bug with '@shopify/react-no-multiple-render-methods'.
 
-## [36.0.0] - 2020-03-28
+## 36.0.0 - 2020-03-28
 
 ### Breaking Change
 
@@ -192,20 +192,20 @@ rules: {
 }
 ```
 
-## [35.1.0] - 2020-03-23
+## 35.1.0 - 2020-03-23
 
 - Update `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` to 2.25.0, to support new syntax introduced in Typescript 3.8. ([#523](https://github.com/Shopify/eslint-plugin-shopify/pull/523))
 
-## [35.0.0] - 2020-02-14
+## 35.0.0 - 2020-02-14
 
 - remove `no-vague-titles` because the rule was adopted into `eslint-plugin-jest`'s `valid-title` rule. See [the `valid-title` documentation](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-title.md#disallowedwords)
 - Fixed an issue with `typescript/prefer-pascal-case-enum` when you had enum with key as string. ([517](https://github.com/Shopify/eslint-plugin-shopify/pull/517))
 
-## [34.0.1] - 2019-01-13
+## 34.0.1 - 2019-01-13
 
 - fix enabled graphql rules by specifying `env: 'literal'` ([514](https://github.com/Shopify/eslint-plugin-shopify/pull/518))
 
-## [34.0.0] - 2019-01-13
+## 34.0.0 - 2019-01-13
 
 - changed `no-vague-titles` rule to catch blacklisted **words** (instead of **sequences**) in the title ([514](https://github.com/Shopify/eslint-plugin-shopify/pull/514))
 - removed `jest/no-empty-title` and renamed `jest/require-tothrow-message` to `jest/require-to-throw-message` ([499](https://github.com/Shopify/eslint-plugin-shopify/pull/499))
@@ -219,7 +219,7 @@ The followiing new rules were introduced in `eslint@6.7.0`. More information can
 - [`no-setter-return`](https://eslint.org/docs/rules/no-setter-return)
 - [`prefer-exponentiation-operator`](https://eslint.org/docs/rules/prefer-exponentiation-operator)
 
-## [33.0.0] - 2019-11-20
+## 33.0.0 - 2019-11-20
 
 ### Breaking Change
 
@@ -244,14 +244,14 @@ The followiing new rules were introduced in `eslint@6.7.0`. More information can
 - `shopify/no-all-mocks-methods` ([#204](https://github.com/Shopify/eslint-plugin-shopify/pull/204))
 - `shopify/no-namespace-imports` Prevent namespace import declarations. ([262](https://github.com/Shopify/eslint-plugin-shopify/pull/262))
 
-## [32.0.0] - 2019-11-05
+## 32.0.0 - 2019-11-05
 
 - `jest/valid-title`
 - `jest/prefer-hooks-on-top`
 - `jest/require-top-level-describe`
 - Enforce new-lines between groups import groups ([#409](https://github.com/Shopify/eslint-plugin-shopify/pull/409))
 
-## [31.0.0] - 2019-10-23
+## 31.0.0 - 2019-10-23
 
 ### Breaking Change
 
@@ -308,11 +308,11 @@ _Example config for react with typescript projects:_
 - `jest/no-expect-resolves` Avoid using `expect().resolves` ([370](https://github.com/Shopify/eslint-plugin-shopify/pull/370))
 
 
-## [30.0.1] - 2019-06-24
+## 30.0.1 - 2019-06-24
 
 - bump eslint peer depndency to 6
 
-## [30.0.0] - 2019-06-24
+## 30.0.0 - 2019-06-24
 
 ### Changed
 
@@ -327,19 +327,19 @@ _Example config for react with typescript projects:_
 
 - [Patch] Fix `jest/no-if` from falsely reporting if statements inside of functions ([331](https://github.com/Shopify/eslint-plugin-shopify/pull/331))
 
-## [29.0.2] - 2019-06-18
+## 29.0.2 - 2019-06-18
 
 ### Changed
 
 - Removed `react/prop-types` in typescript config ([309](https://github.com/Shopify/eslint-plugin-shopify/pull/309))
 
-## [29.0.1] - 2019-06-18
+## 29.0.1 - 2019-06-18
 
 ### Changed
 
 - Removed `import/no-namespace` ([308](https://github.com/Shopify/eslint-plugin-shopify/pull/308))
 
-## [29.0.0] - 2019-06-17
+## 29.0.0 - 2019-06-17
 
 ### Changed
 
@@ -361,7 +361,7 @@ _Example config for react with typescript projects:_
 - `shopify/jest/no-if` ignores if statements nested within block statements ([299](https://github.com/Shopify/eslint-plugin-shopify/pull/299))
 - `react-prefer-private-members` from incorrectly reporting the members of a parent class if a React class is defined within its constructor. ([258](https://github.com/Shopify/eslint-plugin-shopify/pull/258))
 
-## [28.0.0] - 2019-04-26
+## 28.0.0 - 2019-04-26
 
 ### Changed
 
@@ -401,7 +401,7 @@ _Example config for react with typescript projects:_
 
 * turned off `node/no-extraneous-require` because it duplicates reported violations from `import/no-extraneous-dependencies` ([#240](https://github.com/Shopify/eslint-plugin-shopify/pull/240)
 
-## [27.0.1] - 2019-04-10
+## 27.0.1 - 2019-04-10
 
 ### Changed
 
@@ -414,7 +414,7 @@ _Example config for react with typescript projects:_
 * turned off `babel/camelcase` in typescript config because it overlaps with `@typescript-eslint/camelcase`. ([#238](https://github.com/Shopify/eslint-plugin-shopify/pull/238))
 * `shopify/jest/no-if` no longer considers if statements in describe blocks as invalid. ([#235](https://github.com/Shopify/eslint-plugin-shopify/pull/235))
 
-## [27.0.0] - 2019-04-08
+## 27.0.0 - 2019-04-08
 
 ### Added
 
@@ -494,19 +494,19 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 * `jest/no-vague-titles` added `every` and `descriptive` as vague words. ([#221](https://github.com/Shopify/eslint-plugin-shopify/pull/221))
 
-## [26.3.0] - 2019-02-21
+## 26.3.0 - 2019-02-21
 
 ### Added
 
 * Updated `eslint-plugin-react` and enabled `react/jsx-fragments` rule to prefer using `<>` over `<React.Fragment>` when defining fragments ([#223](https://github.com/Shopify/eslint-plugin-shopify/pull/223))
 
-## [26.2.0] - 2019-02-14
+## 26.2.0 - 2019-02-14
 
 ### Added
 
 * `images-no-direct-imports` ([#219](https://github.com/Shopify/eslint-plugin-shopify/pull/219))
 
-## [26.1.2] - 2019-01-02
+## 26.1.2 - 2019-01-02
 
 ### Fixed
 
@@ -517,13 +517,13 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 * `jest/no-vague-titles` added `should` and `properly` to vague rules and new configuration to `allow` words. ([#208](https://github.com/Shopify/eslint-plugin-shopify/pull/208))
 
-## [26.1.1] - 2018-10-31
+## 26.1.1 - 2018-10-31
 
 ### Fixed
 
 * `typescript-eslint-parser` pinned at `20.0.0` to avoid [a known issue](https://github.com/eslint/typescript-eslint-parser/issues/535) ([#201](https://github.com/Shopify/eslint-plugin-shopify/pull/201))
 
-## [26.1.0] - 2018-10-30
+## 26.1.0 - 2018-10-30
 
 ### Added
 
@@ -533,7 +533,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 * Set TypeScript parser only on TS files. This makes sure you can extend from the typescript and react configs in either order. Previously you had to make sure typescript came first to avoid using the babel-eslint parser on typescript files. Now we suggest to extend from typescript, and then react to ensure some rules some JSX rules don't get inadventently disabled. ([#200](https://github.com/Shopify/eslint-plugin-shopify/pull/200))
 
-## [26.0.0] - 2018-10-26
+## 26.0.0 - 2018-10-26
 
 ### Added
 
@@ -559,26 +559,26 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 * Rolling back `eslint-plugin-graphql` to `2.1.0-0` for multiple schema support ([#195](https://github.com/Shopify/eslint-plugin-shopify/pull/195))
 
-## [25.1.0] - 2018-10-01
+## 25.1.0 - 2018-10-01
 
 ### Changed
 
 * Updated `typescript-eslint-parser` dependency to version 19.0.2 to support `typescript-estree`. ([#176](https://github.com/Shopify/eslint-plugin-shopify/pull/176))
 
-## [25.0.1] - 2018-09-25
+## 25.0.1 - 2018-09-25
 
 ### Fixed
 
 * Restored `typescript-prettier` config to override `prettier` plugin parser. ([#171](https://github.com/Shopify/eslint-plugin-shopify/pull/171))
 
-## [25.0.0] - 2018-09-25
+## 25.0.0 - 2018-09-25
 
 ### Fixed
 
 * Updated `plugin:shopify/prettier` to enable prettier linting. ([#170](https://github.com/Shopify/eslint-plugin-shopify/pull/170))
 * `strict-component-boundaries` now consistently uses the resolved path from the app root to perform its checks. This fixes a number of false-positives. ([#160](https://github.com/Shopify/eslint-plugin-shopify/pull/160))
 
-## [24.2.0] - 2018-09-21
+## 24.2.0 - 2018-09-21
 
 ### Added
 
@@ -588,17 +588,17 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 * Updated `no-vague-titles` rule to fix parsing issues in `getMethodName`. ([#167](https://github.com/Shopify/eslint-plugin-shopify/pull/167))
 
-## [24.1.1] - 2018-09-19
+## 24.1.1 - 2018-09-19
 
 * Same as `24.1.0`
 
-## [24.1.0] - 2018-09-19
+## 24.1.0 - 2018-09-19
 
 ### Added
 
 * Added `shopify/graphql` config using new `eslint-plugin-graphql` (`2.1.1.`) dependency. ([#165](https://github.com/Shopify/eslint-plugin-shopify/pull/165))
 
-## [24.0.0] - 2018-08-30
+## 24.0.0 - 2018-08-30
 
 ### Fixed
 
@@ -650,7 +650,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
   * [`typescript/no-var-requires`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-var-requires.md)
 
 
-## [23.1.0] - 2018-08-02
+## 23.1.0 - 2018-08-02
 
 ### Fixed
 
@@ -661,7 +661,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 * Included `all` as a vague term for `no-vague-titles` ([#114](https://github.com/Shopify/eslint-plugin-shopify/pull/114))
 
-## [23.0.0] - 2018-07-16
+## 23.0.0 - 2018-07-16
 
 * **Breaking** `eslint-plugin-shopify` will no longer install `prettier` as a dependency. Please ensure you have added `prettier` to your `package.json` if you wish to use it.
 
@@ -676,7 +676,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 * **Breaking** Moved prettier to be a peerDependency, this avoids the potential for having multiple versions of prettier in the dependency graph. If you use prettier you will need to ensure you have it installed in your project as eslint-plugin-shopify will no longer install it for you ([#107](https://github.com/Shopify/eslint-plugin-shopify/pull/107))
 * **Breaking** Updated `typescript-eslint-parser` to support `typescript@2.9.1` ([#102](https://github.com/Shopify/eslint-plugin-shopify/pull/102))
 
-## [22.1.0] - 2018-06-08
+## 22.1.0 - 2018-06-08
 
 ### Fixed
 
@@ -687,16 +687,16 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 * `shopify/prefer-pascal-case-enums` ([#96](https://github.com/Shopify/eslint-plugin-shopify/pull/96))
 * `shopify/react-prefer-private-members` ([#95](https://github.com/Shopify/eslint-plugin-shopify/pull/95))
 
-## [22.0.0]
+## 22.0.0
 
 * Updated dependencies
 * Added support for TypeScript 2.8
 
-## [21.0.1] - 2018-04-25
+## 21.0.1 - 2018-04-25
 
 * Fixed the publish config for the package.
 
-## [21.0.0] - 2018-04-25
+## 21.0.0 - 2018-04-25
 
 ### Added
 
@@ -717,7 +717,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 * Fixed an issue where various rules were not correctly resolving paths in `node_modules`.
 
-## [20.0.0] - 2018-03-15
+## 20.0.0 - 2018-03-15
 
 * **Breaking:** the version of TypeScript supported by this plugin is 2.7.x (in line with [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser)’s TypeScript support)
 * Updated dependencies that support the new ESLint documentation URL metadata. Errors from these plugins are accompanied by a link to the documentation for the broken rule.
@@ -759,13 +759,13 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 * Updated `import/extensions` due to changes in its implementation: some extensions are explicitly allowed in `import`s: `.svg`, `.png`, `.jpg`, `.ico`, `.css`, `.sass`, `.scss`, `.less`, `.styl`. `.json` is still required as well.
 * Chore: updated CircleCI from v1 to v2.
 
-## [19.0.1] - 2018-03-12
+## 19.0.1 - 2018-03-12
 
 ### Fixed
 
 * `shopify/jsx-no-hardcoded-content` rule now does not warn on all-whitespace strings as children. This was causing issues with indented JSX content, and is typically not an issue for different locales.
 
-## [19.0.0] - 2018-01-17
+## 19.0.0 - 2018-01-17
 
 ### Added
 
@@ -841,25 +841,25 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
     ```
 * Prettified source files using the new config
 
-## [18.3.1] - 2017-12-21
+## 18.3.1 - 2017-12-21
 
 ### Changed
 
 * Changed `eslint-config-shopify` codebase to follow es5 trailingComma [[#61](https://github.com/Shopify/eslint-plugin-shopify/pull/61)]
 
-## [18.3.0] - 2017-12-18
+## 18.3.0 - 2017-12-18
 
 ### Added
 
 * Added `shopify/no-debugger`, which behaves the same as ESLint's `no-debugger` but without a fixer.
 
-## [18.2.0] - 2017-12-04
+## 18.2.0 - 2017-12-04
 
 ### Added
 
 * Added a `typescript-prettier` config to run prettier against typescript projects.
 
-## [18.1.0] - 2017-12-01
+## 18.1.0 - 2017-12-01
 
 ### Added
 
@@ -881,19 +881,19 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
   }
   ```
 
-## [18.0.0] - 2017-10-31
+## 18.0.0 - 2017-10-31
 
 ### Changed
 
 * Turned off `class-methods-use-this`
 
-## [17.2.1] - 2017-10-30
+## 17.2.1 - 2017-10-30
 
 ### Changed
 
 * Turned off `babel/semi` rule in prettier config
 
-## [17.2.0] - 2017-10-25
+## 17.2.0 - 2017-10-25
 
 ### Added
 
@@ -919,7 +919,7 @@ Example:
 * `lines-around-directive` was deprecated in ESLint `v4.0.0`. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 
-## [17.1.0] - 2017-09-19
+## 17.1.0 - 2017-09-19
 
 ### Added
 
@@ -960,7 +960,7 @@ Example:
 
 - `jsx-a11y/href-no-hash` replaced with `jsx-a11y/anchor-is-valid`
 
-## [17.0.0] - 2017-08-17
+## 17.0.0 - 2017-08-17
 
 ### Changed
 
@@ -975,13 +975,13 @@ Example:
   - `eslint-plugin-react`: `^7.0.0` → `^7.0.1`.
 
 
-## [16.0.1] - 2017-05-29
+## 16.0.1 - 2017-05-29
 
 ### Changed
 
 - Turned off [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring) ([#30](https://github.com/Shopify/eslint-plugin-shopify/pull/30))
 
-## [16.0.0] - 2017-05-16
+## 16.0.0 - 2017-05-16
 
 ### Added
 
@@ -1024,19 +1024,19 @@ Example:
 - Deprecated: [`jsx-a11y/jsx-space-before-closing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06)
 
 
-## [15.2.0] - 2017-03-06
+## 15.2.0 - 2017-03-06
 
 ### Changed
 
 - `eslint` upgrade to `3.17.x`
 
-## [15.1.2] - 2017-02-23
+## 15.1.2 - 2017-02-23
 
 ### Fixed
 
 - `jquery-dollar-sign-reference` now checks assignments from `LogicalExpression` / `BinaryExpression`
 
-## [15.1.1] - 2017-01-17
+## 15.1.1 - 2017-01-17
 
 ### Added
 
@@ -1055,36 +1055,6 @@ Example:
 
 - Removed `eslint-find-rules` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
-## [15.1.0]
+## 15.1.0
 
 Changes were originally tracked in Shopify's [JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).
-
-[Unreleased]: https://github.com/Shopify/eslint-plugin-shopify/compare/v26.3.0...HEAD
-[26.3.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v26.2.0...v26.3.0
-[26.2.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v26.1.2...v26.2.0
-[26.1.2]: https://github.com/Shopify/eslint-plugin-shopify/compare/v26.1.1...v26.1.2
-[26.1.1]: https://github.com/Shopify/eslint-plugin-shopify/compare/v26.1.0...v26.1.1
-[26.1.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v26.0.0...v26.1.0
-[26.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v25.1.0...v26.0.0
-[25.1.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v25.0.1...v25.1.0
-[25.0.1]: https://github.com/Shopify/eslint-plugin-shopify/compare/v25.0.0...v25.0.1
-[25.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v24.2.0...v25.0.0
-[24.2.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v24.1.1...v24.2.0
-[24.1.1]: https://github.com/Shopify/eslint-plugin-shopify/compare/v24.1.0...v24.1.1
-[24.1.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v24.0.0...v24.1.0
-[24.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v23.1.0...v24.0.0
-[23.1.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v23.0.0...v23.1.0
-[23.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v22.1.0...v23.0.0
-[22.1.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v22.0.0...v22.1.0
-[22.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v21.0.1...v22.0.0
-[21.0.1]: https://github.com/Shopify/eslint-plugin-shopify/compare/v21.0.0...v21.0.1
-[21.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v20.0.0...v21.0.0
-[20.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v19.0.1...v20.0.0
-[19.0.1]: https://github.com/Shopify/eslint-plugin-shopify/compare/v19.0.0...v19.0.1
-[19.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.3.1...v19.0.0
-[18.3.1]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.3.0...v18.3.1
-[18.3.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.2.0...v18.3.0
-[18.2.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.1.0...v18.2.0
-[18.1.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.0.0...v18.1.0
-[18.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v17.2.1...v18.0.0
-[17.2.1]: https://github.com/Shopify/eslint-plugin-shopify/compare/v17.2.0...v17.2.1

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -5,17 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+<!-- ## Unreleased -->
 
-## [2.0.1] - 2020-03-28
+## 2.0.1 - 2020-03-28
 
 - Update internal dependencies and update tests ([#10](https://github.com/Shopify/images/pull/10))
 
-## [2.0.0] - 2019-06-03
+## 2.0.0 - 2019-06-03
 
 - Removed `removeDimensions` svg optimization ([#13](https://github.com/Shopify/images/pull/13))
 - Removed icon-loader and related SVGSource as we now use SVGr for loading icons ([#14](https://github.com/Shopify/images/pull/14))
 
-## [1.1.5] - 2018-05-04
+## 1.1.5 - 2018-05-04
 
 - CHANGELOG created

--- a/packages/postcss-plugin/CHANGELOG.md
+++ b/packages/postcss-plugin/CHANGELOG.md
@@ -5,21 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+<!-- ## Unreleased -->
 
-## [4.1.0] - 2021-04-16
+## 4.1.0 - 2021-04-16
 
 - Update `cssnano` to version `5.0.0`. [[#233](https://github.com/Shopify/web-configs/pull/233)]
 
-## [4.0.0] - 2021-04-16
+## 4.0.0 - 2021-04-16
 
 - Updating to postcss 8 (which drops support for node 11/13 but no major api changes). [[#225](https://github.com/Shopify/web-configs/pull/225)]
 
-## [3.1.0] - 2020-09-17
+## 3.1.0 - 2020-09-17
 
 - Dependency updates [[#159](https://github.com/Shopify/web-foundations/pull/159)]
 
-## [3.0.0] - 2020-03-28
+## 3.0.0 - 2020-03-28
 
 🚨Package rename
 
@@ -45,19 +45,19 @@ module.exports = {
 };
 ```
 
-## [2.2.1] - 2019-01-17
+## 2.2.1 - 2019-01-17
 
 - Removed a potentially buggy transform from the `minimize`-based preset
 
-## [2.2.0] - 2018-11-26
+## 2.2.0 - 2018-11-26
 
 - Added the `minimize` option to optionally enable `cssnano`.
 
-## [2.1.0] - 2018-11-22
+## 2.1.0 - 2018-11-22
 
 - Updated to the latest version of all dependencies.
 
-## [2.0.0] - 2018-08-30
+## 2.0.0 - 2018-08-30
 
 Breaking change: updated dependencies to use PostCSS 7.0.
 
@@ -69,14 +69,10 @@ Breaking change: updated dependencies to use PostCSS 7.0.
 - Updated postcss-selector-matches: `^2.0.5` -> `^3.0.1` ([changelog](https://github.com/postcss/postcss-selector-matches/blob/master/CHANGELOG.md))
 - Updated postcss-will-change: `^1.1.0` -> `^2.0.0` ([changelog](https://github.com/postcss/postcss-will-change/blob/master/CHANGELOG.md))
 
-## [1.0.1] - 2018-01-17
+## 1.0.1 - 2018-01-17
 
 - Discard comments in the last processing step, allowing to use comments such as `/* autoprefixer: off */` ([#2](https://github.com/Shopify/postcss-shopify/pull/2))
 
-## [1.0.0] - 2017-03-05
+## 1.0.0 - 2017-03-05
 
 - Initial release
-
-[Unreleased]: https://github.com/Shopify/postcss-shopify/compare/v2.0.0...master
-[2.0.0]: https://github.com/Shopify/postcss-shopify/compare/v1.0.1...v2.0.0
-[1.0.1]: https://github.com/Shopify/postcss-shopify/compare/v1.0.0...v1.0.1

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2020-05-14
+<!-- ## Unrelased -->
+
+## 1.1.0 - 2020-05-14
 
 ### Changed
 
 - Explicitly set default for `"arrowParens": "always"`.  Although it is a default for prettier as of v2.0, it was `avoid` in prior versions.  Specifying it explicitly here will result in the same config, not matter which version of prettier used.
 
-## [1.0.0] - 2020-05-12
+## 1.0.0 - 2020-05-12
 
 ### Added
 

--- a/packages/stylelint-plugin/CHANGELOG.md
+++ b/packages/stylelint-plugin/CHANGELOG.md
@@ -5,31 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
 
 ### Changed
 
 - Remove `no-invalid-position-at-import-rule` rule as it is not in a currently released version of stylelint [[#237](https://github.com/Shopify/web-configs/pull/237)]
 - Update peer dependency to `>=13.12.0` [[#237](https://github.com/Shopify/web-configs/pull/237)]
 
-## [10.1.0] - 2021-03-10
+## 10.1.0 - 2021-03-10
 
 ### Changed
 
 - Update `stylelint`, `stylelint-prettier`, and `stylelint-scss` [[#224](https://github.com/Shopify/web-configs/pull/224)]
 
-## [10.0.1] - 2020-10-07
+## 10.0.1 - 2020-10-07
 
 - Update stylelint peer dependency to `>=13.7.0"`
 
-## [10.0.0] - 2020-10-06
+## 10.0.0 - 2020-10-06
 
 ### Breaking Change
 
 - Projects will need to use stylelint v13.7.0 or higher 
 - Stylelint rules have been renamed. `*-blacklist`, `*-requirelist` and `*-whitelist` rules have been replaced in favour of the new `*-disallowed-list`, `*-required-list` and `*-allowed-list` ones.
 
-## [9.0.0] - 2020-06-04
+## 9.0.0 - 2020-06-04
 
 ### Breaking Change
 
@@ -57,11 +57,11 @@ module.exports = {
 };
 ```
 
-## [8.1.0] - 2020-05-12
+## 8.1.0 - 2020-05-12
 
 - Loosen the `selector-class-pattern` rule to allow for hypens in class names ([#153](https://github.com/Shopify/web-foundation/pull/153))
 
-## [8.0.0] - 2020-03-28
+## 8.0.0 - 2020-03-28
 
 - Bump `stylelint-config-prettier@^4.0.0` to `stylelint-config-prettier@^8.0.1`
 - Bump `stylelint-order@^2.2.1` to `stylelint-order@^4.0.0`
@@ -93,7 +93,7 @@ After:
 - Add jest and bump node to 10.0.0 ([#55](https://github.com/Shopify/stylelint-config-shopify/pull/55)
 - Rename "rules" folder - which contains config for existing rules to be "config"; Rename "plugins" folder which contains our custom rule definitions to be "rules". This matches the layout used by eslint-plugin-shopify. ([#56](https://github.com/Shopify/stylelint-config-shopify/pull/56))
 
-## [7.4.0] - 2019-12-16
+## 7.4.0 - 2019-12-16
 
 ### Added
 
@@ -110,46 +110,46 @@ After:
 
 - Bump stylelint-prettier v1.1.2 ([#54](https://github.com/Shopify/stylelint-config-shopify/pull/54)
 
-## [7.3.0] - 2019-12-14
+## 7.3.0 - 2019-12-14
 
 ### Added
 
 - Forbid `display: table` for better Safari + VoiceOver + iOS compatibility ([#52](https://github.com/Shopify/stylelint-config-shopify/pull/52))
 
-## [7.2.1] - 2019-04-04
+## 7.2.1 - 2019-04-04
 
 - Fixed an regression where 7.2.0 introduced the need for stylelint 9.9.0 or above ([#50](https://github.com/Shopify/stylelint-config-shopify/pull/50))
 
-## [7.2.0] - 2019-04-03
+## 7.2.0 - 2019-04-03
 
 - Allow non-lowercase values in properties such as `font`, `font-family`, `--anything-with-font-in-its-name`, or Sass variables starting with `$polaris` or containing `font` ([#49](https://github.com/Shopify/stylelint-config-shopify/pull/49))
 
-## [7.1.0] - 2019-01-07
+## 7.1.0 - 2019-01-07
 
 - Raise `peerDependency` on `stylelint` to 9.4.0 to accomodate the `linebreaks` rule. ([#46](https://github.com/Shopify/stylelint-config-shopify/pull/46))
 - Bump `stylelint-prettier` to v1.0.6 to fix crashes when reading unparsable files. ([#48](https://github.com/Shopify/stylelint-config-shopify/pull/48))
 
-## [7.0.4] - 2018-10-02
+## 7.0.4 - 2018-10-02
 
 - Bump stylelint-prettier v1.0.3 to avoid a transitive dependency on eslint-plugin-prettier ([#45](https://github.com/Shopify/stylelint-config-shopify/pull/45))
 
-## [7.0.3] - 2018-09-27
+## 7.0.3 - 2018-09-27
 
 - Redeploy of `7.0.2` to update `latest` version reference on npm.
 
-## [7.0.2] - 2018-09-13
+## 7.0.2 - 2018-09-13
 
 ### Changed
 
 - Disable `scss/no-duplicate-dollar-variables` rule by default. It makes no attempt to understand how Sass's variable scoping works which results in lots of false warnings on completely reasonable code. ([#44](https://github.com/Shopify/stylelint-config-shopify/pull/44))
 
-## [7.0.1] - 2018-09-12
+## 7.0.1 - 2018-09-12
 
 ### Changed
 
 - Updated stylelint-prettier to v1.0.1 ([#42](https://github.com/Shopify/stylelint-config-shopify/pull/42))
 
-## [7.0.0] - 2018-08-30
+## 7.0.0 - 2018-08-30
 
 ### Changed
 
@@ -163,11 +163,11 @@ After:
   - [scss/no-duplicate-dollar-variables](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/no-duplicate-dollar-variables/README.md)
 
 
-## [6.1.0] - 2018-08-07
+## 6.1.0 - 2018-08-07
 
 - Update dependency: use stylelint-config-prettier v4.0.0. This is identical to v3.3.0 except it moves stylelint to be a peerDependency, which means there is less chance for installing multiple versions of stylelint.
 
-## [6.0.0] - 2018-08-07
+## 6.0.0 - 2018-08-07
 
 - Changed dependency: Use `stylelint-prettier` for prettier integration instead of `prettier-stylelint-formatter`. `stylelint-prettier` is a stylelint plugin that exposes prettier issues as stylelint rule violations. This means you can use `stylelint --fix` to fix formatting issues that prettier raises instead of having to use different executables for showing and autofixing issues.
 
@@ -179,12 +179,12 @@ Migration Suggestions:
   yarn remove prettier-stylelint-formatter
   ```
 
-## [5.1.2] - 2018-07-10
+## 5.1.2 - 2018-07-10
 
 - Changed dependency: Pull the base prettier config from stylelint-config-prettier instead of  prettier-stylelint-formatter. It is provided by the prettier organisation and is more up to date than the one provided by prettier-stylelint-formatter
 - Increase stylelint minimum version to 9.1.1 so it aligns with the minumum required by stylelint-config-prettier
 
-## [5.1.1] - 2018-07-10
+## 5.1.1 - 2018-07-10
 
 - Added a new custom rule `shopify/content-no-strings` that disallows hard-coded strings as values for the `content` property. This prevents internationalization issues. Keywords are still allowed. The rule is not enabled by default.
 
@@ -208,22 +208,22 @@ The following patterns are _not_ considered violations:
 .foo::before { content: open-quote counter(section_counter) close-quote; }
 ```
 
-## [5.1.0] - 2018-07-05
+## 5.1.0 - 2018-07-05
 
 - Use 5.1.1 instead.
 
-## [5.0.1] - 2018-04-06
+## 5.0.1 - 2018-04-06
 
 - Updated dependency: stylelint-css (no breaking changes, only fixes)
 - Updated devDependencies: eslint, eslint-plugin-shopify
 
-## [5.0.0] - 2018-02-22
+## 5.0.0 - 2018-02-22
 
 - Dropped support for Node `<8.9`
 - Require stylelint `>=9.0` as a peerDependency for projects consuming this config ([#25](https://github.com/Shopify/stylelint-config-shopify/pull/25) and [#27](https://github.com/Shopify/stylelint-config-shopify/pull/27))
 - Updated dependencies
 
-## [4.0.0] - 2017-11-17
+## 4.0.0 - 2017-11-17
 
 - Replaces [`prettier-stylelint`](https://github.com/hugomrdias/prettier-stylelint) with a [forked](https://github.com/ismail-syed/prettier-stylelint-formatter) version addressing an [issue](https://github.com/hugomrdias/prettier-stylelint/issues/3) [#23](https://github.com/Shopify/stylelint-config-shopify/pull/23)
 
@@ -235,11 +235,11 @@ Migration Suggestions:
     yarn remove prettier-stylelint && yarn add prettier-stylelint-formatter
     ```
 
-## [3.0.2] - 2017-11-14
+## 3.0.2 - 2017-11-14
 
 * `declaration-block-no-redundant-longhand-properties` now allows longhand `grid` properties, see [#21](https://github.com/Shopify/stylelint-config-shopify/pull/21)
 
-## [3.0.1] - 2017-11-13
+## 3.0.1 - 2017-11-13
 
 - Removed `position: fixed` from the property value blacklist, see [#18](https://github.com/Shopify/stylelint-config-shopify/pull/18)
 - Allowed digits in class selector names (e.g. `.rotate180`), see [#17](https://github.com/Shopify/stylelint-config-shopify/pull/17)
@@ -291,7 +291,7 @@ The following patterns are considered warnings:
 }
 ```
 
-## [2.1.0] - 2017-08-25
+## 2.1.0 - 2017-08-25
 
 
 ### Changed
@@ -301,13 +301,13 @@ The following patterns are considered warnings:
 * Replaced deprecated `scss/at-mixin-no-argumentless-call-parentheses` rule with its equivalent `scss/at-mixin-argumentless-call-parentheses`
 * Updated `eslint-plugin-shopify` to the latest version, and updated ESLint to the appropriate version
 
-## [2.0.1] - 2017-07-28
+## 2.0.1 - 2017-07-28
 
 ### Changed
 
 * Set `selector-max-type` to 1
 
-## [2.0.0] - 2017-07-27
+## 2.0.0 - 2017-07-27
 
 ### Added
 
@@ -351,30 +351,6 @@ The following patterns are considered warnings:
 property: <top> <right> <bottom> <left>
 ```
 
-## [1.0.0] - 2017-05-29
+## 1.0.0 - 2017-05-29
 
 * Initial release
-
-[7.3.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.3.0...v7.4.0
-[7.3.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.2.1...v7.3.0
-[7.2.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.2.0...v7.2.1
-[7.2.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.1.0...v7.2.0
-[7.1.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.4...v7.1.0
-[7.0.4]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.3...v7.0.4
-[7.0.3]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.2...v7.0.3
-[7.0.2]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.1...v7.0.2
-[7.0.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v7.0.0...v7.0.1
-[7.0.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v6.1.0...v7.0.0
-[6.1.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v6.0.0...v6.1.0
-[6.0.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.1.2...v6.0.0
-[5.1.2]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.1.1...v5.1.2
-[5.1.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.1.0...v5.1.1
-[5.1.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.0.1...v5.1.0
-[5.0.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v5.0.0...v5.0.1
-[5.0.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v4.0.0...v5.0.0
-[4.0.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v3.0.2...v4.0.0
-[3.0.2]: https://github.com/Shopify/stylelint-config-shopify/compare/v3.0.1...v3.0.2
-[3.0.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v2.1.0...v3.0.1
-[2.1.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v2.0.1...v2.1.0
-[2.0.1]: https://github.com/Shopify/stylelint-config-shopify/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/Shopify/stylelint-config-shopify/compare/v1.0.0...v2.0.0

--- a/packages/typescript-configs/CHANGELOG.md
+++ b/packages/typescript-configs/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+<!-- ## Unreleased -->
 
-## [4.0.0] - 2021-02-24
+## 4.0.0 - 2021-02-24
 
 ### Breaking Change
 
 Set `isolatedModules` to be true by default. Sewing-kit is moving away from a `tsc` based compilation process, towards using babel/esbuild only single file transpilation. Prepare consumers for this change by making type-checking identify code that can be problematic with single-file transpilers. [[#214](https://github.com/Shopify/web-configs/pull/214)]
 
-## [3.0.0] - 2020-06-04
+## 3.0.0 - 2020-06-04
 
 ### Breaking Change
 
@@ -33,7 +33,7 @@ import styles from 'foo.scss';
 
 - Updated the `*.scss` and `*.css` types for esmodules [[#165](https://github.com/Shopify/web-configs/pull/165)]
 
-## [2.0.2] - 2020-03-28
+## 2.0.2 - 2020-03-28
 
 - Start of Changelog
 - Move the package from [`sewing-kit`](https://github.com/Shopify/sewing-kit).

--- a/scripts/lint-changelogs.js
+++ b/scripts/lint-changelogs.js
@@ -9,13 +9,13 @@ const changelogs = readChangelogs();
 console.log(`🕵️‍♂️  Checking ${changelogs.length} changelogs`);
 
 const haveUnreleasedHeader = changelogs.filter(({packageChangelog}) =>
-  packageChangelog.split('\n').find((line) => /^## \[Unreleased\]/.exec(line)),
+  packageChangelog.split('\n').find((line) => /^## Unreleased/.exec(line)),
 );
 
 if (haveUnreleasedHeader.length > 0) {
   console.error(
     [
-      `❌ Found uncommented "## [Unreleased]" headers in one or more changelogs. These file(s) should be kept in-synch with the version(s) you are releasing. Update all changelogs to reflect the version you intend to release or the last released version and run yarn release again.`,
+      `❌ Found uncommented "## Unreleased" headers in one or more changelogs. These file(s) should be kept in-synch with the version(s) you are releasing. Update all changelogs to reflect the version you intend to release or the last released version and run yarn release again.`,
       'Violations:',
       ...haveUnreleasedHeader.map(
         ({packageChangelogPath}) => `- ${packageChangelogPath}`,

--- a/test/consistent-changelogs.test.js
+++ b/test/consistent-changelogs.test.js
@@ -67,10 +67,10 @@ readChangelogs().forEach(({packageChangelogPath, packageChangelog}) => {
 
 const allowedHeaders = [
   '# Changelog',
-  '## [Unreleased]',
-  /^## \[\d+\.\d+\.\d+\] - \d\d\d\d-\d\d-\d\d$/,
+  '## Unreleased',
+  /^## \d+\.\d+\.\d+ - \d\d\d\d-\d\d-\d\d$/,
   // We should backfill dates using commit timestamps
-  /^## \[\d+\.\d+\.\d+\]$/,
+  /^## \d+\.\d+\.\d+$/,
   '### Fixed',
   '### Added',
   '### Changed',


### PR DESCRIPTION
## Description

Unifying with quilt setup. Consistently don't link on changelog headings and thus
remove the need for `[]` wrapping of headings.


No changelog needed 