### PR TITLE
Fix loose warning for @babel/plugin-proposal-private-methods

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+### Changed
+
+- Fix loose warning for `@babel/plugin-proposal-private-methods` [[#245](https://github.com/Shopify/web-configs/pull/245)]
+
 ## 23.6.0 - 2021-05-04
 
 ### Changed

--- a/packages/babel-preset/common.js
+++ b/packages/babel-preset/common.js
@@ -76,6 +76,11 @@ module.exports = function shopifyCommonPreset(
       require.resolve('@babel/plugin-proposal-class-properties'),
       {loose: true},
     ],
+    // The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods
+    typescript && [
+      require.resolve('@babel/plugin-proposal-private-methods'),
+      {loose: true},
+    ],
     // nullish-coalescing, optional-chaining, and numeric separators are handled by preset-env
     // But they aren't yet supported in webpack 4 because of missing support
     // in acorn v6 (support is in acorn v7, which is used in webpack v5).


### PR DESCRIPTION
## Description
This PR fixes this warning message:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [X] `@shopify/babel-preset` <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
