### PR TITLE
Add isWebpack5 to babel-preset to remove some babel plugins when enabled

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Added `isWebpack5` option to remove unneeded babel plugins [[#268](https://github.com/Shopify/web-configs/pull/268)]
 
 ## 24.0.2 - 2021-06-14
 

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -27,6 +27,7 @@ module.exports = function shopifyCommonPreset(
       useBuiltIns: true,
     },
     transformReactConstantElements = false,
+    isWebpack5 = false,
   } = {},
 ) {
   const env = api.env();
@@ -88,11 +89,16 @@ module.exports = function shopifyCommonPreset(
     // See https://github.com/webpack/webpack/issues/10227
     // Can be removed once we drop support for webpack v4 (or these features
     // are backported to acorn v6)
-    typescript && require.resolve('@babel/plugin-proposal-numeric-separator'),
-    typescript &&
+    !isWebpack5 &&
+      typescript &&
+      require.resolve('@babel/plugin-proposal-numeric-separator'),
+    !isWebpack5 &&
+      typescript &&
       require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
 
-    typescript && require.resolve('@babel/plugin-proposal-optional-chaining'),
+    !isWebpack5 &&
+      typescript &&
+      require.resolve('@babel/plugin-proposal-optional-chaining'),
     // Polyfills the runtime needed for async/await, generators, and friends
     // https://babeljs.io/docs/en/babel-plugin-transform-runtime
     transformRuntime && [


### PR DESCRIPTION
## Description
This PR adds `isWebpack5` option to `babel-preset` to remove some plugins when true.

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] `@shopify/babel-preset` <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
