### PR TITLE
Bump Safari / iOS minimum supported versions

### DIFF
--- a/packages/browserslist-config/CHANGELOG.md
+++ b/packages/browserslist-config/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Breaking Change
+
+- Update desktop Safari / iOS Safari minimum supported versions. This brings iOS Safari support inline with the recent updates to Shopify mobile app's minimum supported versions, which now require a minimum version of iOS 13.6. iOS Safari targets `ios >= 13.4` which matches the caniuse target of `ios_saf 13.4-13.7`. Desktop Safari targets `last 3 safari versions` to match other desktop browser support, which matches the caniuse target of `safari 13.1`. [#274](https://github.com/Shopify/web-configs/pull/274)
 
 ## 2.2.4 - 2020-11-03
 

--- a/packages/browserslist-config/index.js
+++ b/packages/browserslist-config/index.js
@@ -1,10 +1,14 @@
 module.exports = [
-  'last 1 firefoxandroid versions',
   'last 3 chrome versions',
-  'last 3 chromeandroid versions',
   'last 3 firefox versions',
   'last 3 opera versions',
   'last 3 edge versions',
-  'safari >= 10',
-  'ios >= 10',
+  'last 3 safari versions',
+  // Mobile browsers
+  // The minimum supported iOS Safari version is 13.6, in line with our mobile
+  // apps, however browserslist thinks `ios >= 13.6` should not include version
+  // `13.4-13.7`, which we do want to support as 13.6 falls within that range
+  'last 3 chromeandroid versions',
+  'last 1 firefoxandroid versions',
+  'ios >= 13.4',
 ];

--- a/packages/browserslist-config/latest-evergreen.js
+++ b/packages/browserslist-config/latest-evergreen.js
@@ -1,9 +1,10 @@
 module.exports = [
   'last 1 chrome versions',
-  'last 1 chromeandroid versions',
   'last 1 firefox versions',
   'last 1 opera versions',
   'last 1 edge versions',
   'last 1 safari major versions',
+  // Mobile browsers
+  'last 1 chromeandroid versions',
   'last 1 ios major versions',
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3367,12 +3367,7 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219:
-  version "1.0.30001234"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001234.tgz#8fc2e709e3b0679d7af7f073a1c661155c39b975"
-  integrity sha512-a3gjUVKkmwLdNysa1xkUAwN2VfJUJyVW47rsi3aCbkRCtbHAfo+rOsCqVw29G6coQ8gzAPb5XBXwiGHwme3isA==
-
-caniuse-lite@^1.0.30001243:
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001243:
   version "1.0.30001243"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz#d9250155c91e872186671c523f3ae50cfc94a3aa"
   integrity sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==


### PR DESCRIPTION
## Description

See #271

Mobile apps have bumped their minimum supported ios version to 13.6.
Web properties should update their minimum supported version too.

Drop support for old safari versions in line with mobile app support.

- For desktop safari use 'last 3 versions' to match other desktop browsers. This equates to Safari 13.1 (released March 2020).
- For ios use 'ios >= 13.4' to match mobile app support of ios 13.6. This equates to iOS Safari caniuse version '13.4-13.7'


## To Test

Run `npx browserslist 'last 3 safari versions'` and note that desktop Safari browser targets are:

```
safari 14.1
safari 14
safari 13.1
```

Run `npx browserslist 'ios >= 13.4'` and note that ios Safari browser targets are:

```
ios_saf 14.5-14.7
ios_saf 14.0-14.4
ios_saf 13.4-13.7
```

Note that running  `npx browserslist 'ios >= 13.6'` omits `ios_saf 13.4-13.7`, which we want to support.

## Type of change

- browserslist-config Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
