### PR TITLE
Port the assumptions strategy to babel-preset@23.6.x

### DIFF
--- a/packages/babel-preset/non-standard-plugins.js
+++ b/packages/babel-preset/non-standard-plugins.js
@@ -20,17 +20,16 @@ module.exports = function shopifyNonStandardPlugins(options = {}) {
   }
 
   if (typescript) {
-    // proposal-decorators must go before proposal-class-properties.
-    // Typscript implements the stage 1 version of decorators, which is the
-    // "legacy" version. When decorators are used in legacy mode,
-    // proposal-class-properties must be used in loose mode
-    // see https://babeljs.io/docs/en/babel-plugin-proposal-decorators#note-compatibility-with-babel-plugin-proposal-class-properties
+    // class-properties and private-methods are handled by preset-env,
+    // however when enabling decorators you need to add them explicitly after
+    // proposal-decorators.
+    // Typescript implements the stage 1 version of decorators, which is the
+    // "legacy" version. This means that the setPublicClassFields and
+    // privateFieldsAsProperties assumptiions must also be enabled (which is
+    // handled at the bottom of this function)
     plugins.push(
       [require.resolve('@babel/plugin-proposal-decorators'), {legacy: true}],
-      [
-        require.resolve('@babel/plugin-proposal-class-properties'),
-        {loose: true},
-      ],
+      require.resolve('@babel/plugin-proposal-class-properties'),
       require.resolve('@babel/plugin-proposal-numeric-separator'),
       // nullish-coalescing and optional-chaining are handled by preset-env
       // But they aren't yet supported in webpack 4 because of missing support
@@ -39,14 +38,8 @@ module.exports = function shopifyNonStandardPlugins(options = {}) {
       // See https://github.com/webpack/webpack/issues/10227
       // Can be removed once we drop support for webpack v4 (or these features
       // are backported to acorn v6)
-      [
-        require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
-        {loose: true},
-      ],
-      [
-        require.resolve('@babel/plugin-proposal-optional-chaining'),
-        {loose: true},
-      ],
+      require.resolve('@babel/plugin-proposal-nullish-coalescing-operator'),
+      require.resolve('@babel/plugin-proposal-optional-chaining'),
     );
 
     if (transformRuntime) {

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/babel-preset",
-  "version": "23.6.1",
+  "version": "23.6.2",
   "license": "MIT",
   "description": "Shopify's org-wide Babel preset",
   "main": "index.js",

--- a/packages/babel-preset/web.js
+++ b/packages/babel-preset/web.js
@@ -28,8 +28,21 @@ module.exports = function shopifyWebPreset(_api, options = {}) {
     presets.push(require.resolve('@babel/preset-typescript'));
   }
 
+  // When decorators are used in legacy mode proposal-class-properties, plugin-proposal-private-methods must be used in loose mode (this is now handled by these assumptions)
+  // see https://babeljs.io/docs/en/babel-plugin-proposal-decorators#note-compatibility-with-babel-plugin-proposal-class-properties
+  // see https://babeljs.io/docs/en/babel-plugin-proposal-class-properties#loose
+  // see https://babeljs.io/docs/en/babel-plugin-proposal-private-methods#loose
+  // see https://babeljs.io/docs/en/assumptions
+  const assumptions = typescript
+    ? {
+        setPublicClassFields: true,
+        privateFieldsAsProperties: true,
+      }
+    : {};
+
   return {
     presets,
     plugins: nonStandardPlugins(options),
+    assumptions,
   };
 };


### PR DESCRIPTION
## Description
Porting the [last changes](https://github.com/Shopify/web-configs/pull/269) in version 2.6.x

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [x] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
