### PR TITLE
Re-add babel-plugin-react-test-id plugin

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- Re-add `babel-plugin-react-test-id` plugin when running in non-test environments. This was present in v23, but accidentally got removed in v24.0.0.
 
 ## 24.1.2 - 2021-07-27
 

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -9,7 +9,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Re-add `babel-plugin-react-test-id` plugin when running in non-test environments. This was present in v23, but accidentally got removed in v24.0.0.
+- Re-add `babel-plugin-react-test-id` plugin when running in non-test environments. This was present in v23, but accidentally got removed in v24.0.0. [[#284](https://github.com/Shopify/web-configs/pull/284)]
 
 ## 24.1.2 - 2021-07-27
 

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -34,6 +34,7 @@ module.exports = function shopifyCommonPreset(
   const isDevelopment = env === 'development' || env === 'test';
   const includeTransformReactConstantElements =
     !isDevelopment && transformReactConstantElements && react;
+  const includeStripReactTestId = env !== 'test';
 
   const presets = [
     [
@@ -107,6 +108,9 @@ module.exports = function shopifyCommonPreset(
     // result in faster reconciliation
     includeTransformReactConstantElements &&
       require.resolve('@babel/plugin-transform-react-constant-elements'),
+
+    // Only include testID props in the test environment
+    includeStripReactTestId && require.resolve('babel-plugin-react-test-id'),
   ].filter(Boolean);
 
   // When decorators are used in legacy mode proposal-class-properties, plugin-proposal-private-methods must be used in loose mode (this is now handled by these assumptions)


### PR DESCRIPTION

## Description

Strip out testID props in non-test environments.

[This was present in v23](https://unpkg.com/browse/@shopify/babel-preset@23.6.2/react.js#L23) but it seems to have been removed when we consolidated all the files into one in v24. I suspect this was accidental as the package is still listed as a dependency in package.json.

While we've been recommending against using testID props for a long time there's still plenty of usage of it web (love them long tails) so it's probably worth keeping this around.

## Type of change

-  babel-preset Patch: Bug (non-breaking change which fixes an issue)
