### PR TITLE
Update CI to tests multiple node versions, use node 16 locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,22 +2,27 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - '**'
+    branches: ['**']
   push:
-    branches:
-      - 'main'
+    branches: [main]
 
 jobs:
   test:
-    name: 'Test'
+    name: 'Test (${{ matrix.node-version }})'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['12.14', '14.x', '16.x']
+    timeout-minutes: 10
+
     steps:
       - uses: actions/checkout@v2
+        name: Checkout
 
       - uses: actions/setup-node@v2
+        name: Use Node.js ${{ matrix.node-version }}
         with:
-          node-version: '12.14.0'
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
 
       - run: yarn --frozen-lockfile

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: web-configs
 up:
   - node:
-      version: v12.14.0
+      version: v16.13.0
       yarn: v1.22.5
 commands:
   __default__: start
@@ -10,4 +10,3 @@ commands:
   start: echo "Running web-configs is not really a concept that makes sense."
   test: yarnpkg test
   generate: yarnpkg generate
-  


### PR DESCRIPTION
- Run CI against node 12 / 14 / 16. Following a similar pattern to quilt and loom
- Use node 16.13.0 (LTS version) locally

We attempted part of this previously, but bundled it with a bunch of stylelint updates that needed to be reverted in #298