### PR TITLE
Update parser versions

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -9,7 +9,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- Update env and ecmaVersion to '2021' in `esnext` preset to support modern language features. [[#296](https://github.com/Shopify/web-configs/pull/296)]
+- Update env and ecmaVersion to '2021' in `esnext` and`typescript` presets to support modern language features. [[#296](https://github.com/Shopify/web-configs/pull/296), [#304](https://github.com/Shopify/web-configs/pull/304)] 
+- Remove configuring `parserOptions` from the `jest` preset as this handled by the the es5/esnext/typescript presets. [[#304](https://github.com/Shopify/web-configs/pull/304)] 
 
 ## 40.5.0 - 2021-11-18
 

--- a/packages/eslint-plugin/lib/config/core.js
+++ b/packages/eslint-plugin/lib/config/core.js
@@ -3,12 +3,6 @@ const merge = require('merge');
 module.exports = {
   plugins: ['@shopify', 'eslint-comments'],
 
-  parserOptions: {
-    ecmaFeatures: {
-      ecmaVersion: 5,
-    },
-  },
-
   rules: merge(
     require('./rules/best-practices'),
     require('./rules/legacy'),

--- a/packages/eslint-plugin/lib/config/jest.js
+++ b/packages/eslint-plugin/lib/config/jest.js
@@ -5,11 +5,6 @@ module.exports = {
     'jest/globals': true,
   },
 
-  parserOptions: {
-    ecmaVersion: 2015,
-    sourceType: 'module',
-  },
-
   plugins: ['jest', 'jest-formatting', '@shopify'],
 
   rules: merge(require('./rules/jest'), require('./rules/jest-formatting'), {

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -8,7 +8,7 @@ module.exports = {
     {
       parser: '@typescript-eslint/parser',
       parserOptions: {
-        ecmaVersion: 2018,
+        ecmaVersion: 2021,
         sourceType: 'module',
       },
       files: ['*.ts', '*.tsx'],


### PR DESCRIPTION
## Description

Follow up to #296

- use ecmaVersion:2021 in typescript config
- remove setting parser options in the jest config
- remove reference to parserOptions.ecmaFeatures.ecmaVersion in core - 
  this is invalid configuration - it should set parserOptions.ecmaVersion, but that defaults to v5 anyway so this line does nothing

## Type of change

- eslint-plugin - minor
