### PR TITLE
Babel - move options defaults out of default values

### DIFF
--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Breaking Change
+
+- Our defaults that differ from the defaults of the various presets will no longer be overridden if you specify any option to `transformRuntimeOptions` or `reactOptions`. [[#313](https://github.com/Shopify/web-configs/pull/313)]
 
 ## 24.1.5 - 2021-11-18
 

--- a/packages/babel-preset/index.js
+++ b/packages/babel-preset/index.js
@@ -8,24 +8,9 @@ module.exports = function shopifyCommonPreset(
     typescript = false,
     typescriptOptions = {},
     transformRuntime = false,
-    transformRuntimeOptions = {
-      corejs: false,
-      helpers: true,
-      // By default, babel assumes babel/runtime version 7.0.0-beta.0,
-      // explicitly resolving to match the provided helper functions.
-      // https://github.com/babel/babel/issues/10261
-      version: require('@babel/runtime/package.json').version,
-      regenerator: true,
-      // This allows users to run transform-runtime broadly across a whole project.
-      // By default, transform-runtime imports from @babel/runtime/foo directly, but
-      // that only works if @babel/runtime is in the node_modules of the file that is being compiled.
-      absoluteRuntime: false,
-    },
+    transformRuntimeOptions = {},
     react = false,
-    reactOptions = {
-      // Will use the native built-in instead of trying to polyfill behavior for any plugins that require one.
-      useBuiltIns: true,
-    },
+    reactOptions = {},
     transformReactConstantElements = false,
     isWebpack5 = false,
   } = {},
@@ -56,6 +41,8 @@ module.exports = function shopifyCommonPreset(
       {
         // This toggles behavior specific to development, such as adding __source and __self.
         development: isDevelopment,
+        // Will use the native built-in instead of trying to polyfill behavior for any plugins that require one.
+        useBuiltIns: true,
         ...reactOptions,
       },
     ],
@@ -110,8 +97,18 @@ module.exports = function shopifyCommonPreset(
     transformRuntime && [
       '@babel/plugin-transform-runtime',
       {
-        ...transformRuntimeOptions,
+        corejs: false,
+        helpers: true,
+        // By default, babel assumes babel/runtime version 7.0.0-beta.0,
+        // explicitly resolving to match the provided helper functions.
+        // https://github.com/babel/babel/issues/10261
         version: require('@babel/runtime/package.json').version,
+        regenerator: true,
+        // This allows users to run transform-runtime broadly across a whole project.
+        // By default, transform-runtime imports from @babel/runtime/foo directly, but
+        // that only works if @babel/runtime is in the node_modules of the file that is being compiled.
+        absoluteRuntime: false,
+        ...transformRuntimeOptions,
       },
     ],
     // Hoist constant JSX elements to the top of their scope, which can


### PR DESCRIPTION
## Description

Previously as soon as you specified any value for `reactOptions` or `transformRuntimeOptions` it would throw any of our default values.

For instances if you specified `{reactOptions: {runtime:'automatic'}}` then it would throw away our modified default value for `useBuiltIns`. Specifying `{}` would throw away all our defaults.

By moving the defaults down to where the various presets get called users who specify options won't throw away / have to recreate all our defaults.

## Type of change

- babel-preset: Breaking

## Context

I'm considering a future where we start wanting folks to enable the automatic babel runtime.

Prior to this PR doing `['@shopify/babel-preset, {reactOptions: {runtime: 'automatic'}}]` would result in `useBuiltIns` being the babel default of false, instead of our value of true. Forcing consumers to do `{reactOptions: {runtime: 'automatic', useBuiltins: true}}` just to keep our default desired behaviour seems real clunky and undexpected.