### PR TITLE
[Unified Admin] Restrict /admin in Route path literals and templates

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
+## 42.0.0 - 2022-01-17
+
+### Breaking Change
+
+- Restrict /admin in Route path literals and templates [[#315](https://github.com/Shopify/web-configs/pull/315)]
+
 ## 41.0.1 - 2021-12-02
 
 ### Changed

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -132,6 +132,7 @@ This plugin provides the following custom rules, which are included as appropria
 - [images-no-direct-imports](docs/rules/images-no-direct-imports.md): Prevent images from being directly imported.
 - [jest/no-snapshots](docs/rules/jest/no-snapshots.md): Disallows jest snapshots.
 - [jsx-no-complex-expressions](docs/rules/jsx-no-complex-expressions.md): Disallow complex expressions embedded in in JSX.
+- [jsx-no-hardcoded-admin-prefix](docs/rules/jsx-no-hardcoded-admin-prefix.md): Disallows hardcoded /admin prefix in URL paths in JSX Route components.
 - [jsx-no-hardcoded-content](docs/rules/jsx-no-hardcoded-content.md): Disallow hardcoded content in JSX.
 - [jsx-prefer-fragment-wrappers](docs/rules/jsx-prefer-fragment-wrappers.md): Disallow useless wrapping elements in favour of fragment shorthand in JSX.
 - [no-namespace-imports](docs/rules/no-namespace-imports.md): Prevent namespace import declarations.

--- a/packages/eslint-plugin/docs/rules/jsx-no-hardcoded-admin-prefix.md
+++ b/packages/eslint-plugin/docs/rules/jsx-no-hardcoded-admin-prefix.md
@@ -1,0 +1,25 @@
+# Prevent hardcoding /admin prefix to routes. (jsx-no-hardcoded-admin-prefix)
+
+We are on our way to remove the path prefix `/admin` as part of Unified Admin project.
+The prefix is being extracted into a global state/variable to be shared across web as much as we can.
+In the meantime, we draw the line with this rule so we don't keep adding routes with the hardcoded prefix.
+
+## Rule Details
+
+`path` attribute of `Route` components can not contain `/admin` at the beginning of their string literals or templates.
+
+Examples of **incorrect** code for this rule:
+
+```tsx
+
+<Route path="/admin/orders">...</Route>
+
+```
+
+Examples of **correct** code for this rule (please search for `adminPathPrefix` in the code to see where you can grab it from):
+
+```tsx
+
+<Route path={`${adminPathPrefix}/orders`}>...</Route>
+
+```

--- a/packages/eslint-plugin/index.js
+++ b/packages/eslint-plugin/index.js
@@ -6,6 +6,7 @@ module.exports = {
     'jest/no-all-mocks-methods': require('./lib/rules/jest/no-all-mocks-methods'),
     'jest/no-snapshots': require('./lib/rules/jest/no-snapshots'),
     'jsx-no-complex-expressions': require('./lib/rules/jsx-no-complex-expressions'),
+    'jsx-no-hardcoded-admin-prefix': require('./lib/rules/jsx-no-hardcoded-admin-prefix'),
     'jsx-no-hardcoded-content': require('./lib/rules/jsx-no-hardcoded-content'),
     'jsx-prefer-fragment-wrappers': require('./lib/rules/jsx-prefer-fragment-wrappers'),
     'no-ancestor-directory-import': require('./lib/rules/no-ancestor-directory-import'),

--- a/packages/eslint-plugin/lib/config/react.js
+++ b/packages/eslint-plugin/lib/config/react.js
@@ -40,8 +40,8 @@ module.exports = {
     {
       files: ['*.test.*'],
       rules: {
-        'shopify/jsx-no-hardcoded-admin-prefix': 'off',
-        'shopify/jsx-no-hardcoded-content': 'off',
+        '@shopify/jsx-no-hardcoded-admin-prefix': 'off',
+        '@shopify/jsx-no-hardcoded-content': 'off',
       },
     },
   ],

--- a/packages/eslint-plugin/lib/config/react.js
+++ b/packages/eslint-plugin/lib/config/react.js
@@ -26,6 +26,7 @@ module.exports = {
     '@shopify/react-require-autocomplete': 'error',
     '@shopify/react-type-state': 'error',
     '@shopify/jsx-no-complex-expressions': 'error',
+    '@shopify/jsx-no-hardcoded-admin-prefix': 'error',
     '@shopify/jsx-no-hardcoded-content': 'error',
     '@shopify/jsx-prefer-fragment-wrappers': 'error',
     'consistent-return': 'off',
@@ -39,6 +40,7 @@ module.exports = {
     {
       files: ['*.test.*'],
       rules: {
+        'shopify/jsx-no-hardcoded-admin-prefix': 'off',
         'shopify/jsx-no-hardcoded-content': 'off',
       },
     },

--- a/packages/eslint-plugin/lib/config/rules/shopify.js
+++ b/packages/eslint-plugin/lib/config/rules/shopify.js
@@ -11,6 +11,8 @@ module.exports = {
   '@shopify/jest/no-snapshots': 'off',
   // Disallow complex expressions embedded in in JSX.
   '@shopify/jsx-no-complex-expressions': 'off',
+  // Disallow hardcoded /admin in JSX.
+  '@shopify/jsx-no-hardcoded-admin-prefix': 'off',
   // Disallow hardcoded content in JSX.
   '@shopify/jsx-no-hardcoded-content': 'off',
   // Disallow useless wrapping elements in favour of fragment shorthand in JSX.

--- a/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-admin-prefix.js
+++ b/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-admin-prefix.js
@@ -44,7 +44,7 @@ function hasAdminPrefix(node) {
   }
 
   function containsAdmin(value) {
-    return value.endsWith('/admin') || value.indexOf('/admin/') > -1;
+    return value.startsWith('/admin/') || value === '/admin';
   }
 
   function isInvalidProp(propNode) {

--- a/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-admin-prefix.js
+++ b/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-admin-prefix.js
@@ -1,0 +1,64 @@
+const {docsUrl} = require('../utilities');
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow hardcoded /admin occurrences in Route components.',
+      category: 'Best Practices',
+      recommended: false,
+      uri: docsUrl('jsx-no-hardcoded-admin-prefix'),
+    },
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        const adminPrefixFound = hasAdminPrefix(node);
+
+        if (adminPrefixFound) {
+          context.report(
+            node,
+            `Do not use hardcoded path prefix /admin in Route components.`,
+          );
+        }
+      },
+    };
+  },
+};
+
+function hasAdminPrefix(node) {
+  function isInvalidContent(contentNode) {
+    if (
+      contentNode.type === 'Literal' ||
+      contentNode.type === 'JSXText' ||
+      typeof contentNode.value === 'string'
+    ) {
+      return contentNode.value && containsAdmin(contentNode.value);
+    } else if (contentNode.type === 'JSXExpressionContainer') {
+      return isInvalidContent(contentNode.expression);
+    } else if (contentNode.type === 'TemplateLiteral') {
+      return contentNode.quasis.some(isInvalidContent);
+    } else if (contentNode.type === 'TemplateElement') {
+      return containsAdmin(contentNode.value.raw);
+    }
+  }
+
+  function containsAdmin(value) {
+    return value.endsWith('/admin') || value.indexOf('/admin/') > -1;
+  }
+
+  function isInvalidProp(propNode) {
+    return (
+      propNode.type === 'JSXAttribute' &&
+      propNode.name &&
+      propNode.name.name === 'path' &&
+      isInvalidContent(propNode.value)
+    );
+  }
+
+  return (
+    node.openingElement.name.name === 'Route' &&
+    node.openingElement.attributes &&
+    node.openingElement.attributes.find(isInvalidProp)
+  );
+}

--- a/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-admin-prefix.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-admin-prefix.test.js
@@ -47,22 +47,6 @@ ruleTester.run('jsx-no-hardcoded-admin-prefix', rule, {
       errors: errorMessage(),
     },
     {
-      code: '<Route path="/literal/path/with/admin/prefix" />',
-      errors: errorMessage(),
-    },
-    {
-      code: '<Route path={`/template/path/with/admin/prefix`} />',
-      errors: errorMessage(),
-    },
-    {
-      code: '<Route path="/literal/path/with/prefix/admin" />',
-      errors: errorMessage(),
-    },
-    {
-      code: '<Route path={`/template/path/with/prefix/admin`} />',
-      errors: errorMessage(),
-    },
-    {
       code: '<Route path="/admin" />',
       errors: errorMessage(),
     },

--- a/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-admin-prefix.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-admin-prefix.test.js
@@ -1,0 +1,74 @@
+const {RuleTester} = require('eslint');
+
+const rule = require('../../../lib/rules/jsx-no-hardcoded-admin-prefix');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@babel/eslint-parser'),
+  parserOptions: {
+    babelOptions: {
+      presets: [
+        ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
+      ],
+    },
+  },
+});
+
+function errorMessage() {
+  const message =
+    'Do not use hardcoded path prefix /admin in Route components.';
+
+  return [{type: 'JSXElement', message}];
+}
+
+ruleTester.run('jsx-no-hardcoded-admin-prefix', rule, {
+  valid: [
+    {code: '<Route path="/literal/path/without/prefix" />'},
+    {code: '<Route path={`/template/path/without/prefix`} />'},
+    {code: '<div><Route path="/literal/path/without/prefix" /></div>'},
+    {code: '<div><Route path={`/template/path/without/prefix`} /></div>'},
+    {code: '<Route path="/literal/path/without/admin_prefix" />'},
+    {code: '<Route path={`/template/path/without/admin_prefix`} />'},
+  ],
+  invalid: [
+    {
+      code: '<Route path="/admin/literal/path/with/prefix" />',
+      errors: errorMessage(),
+    },
+    {
+      code: '<Route path={`/admin/template/path/with/prefix`} />',
+      errors: errorMessage(),
+    },
+    {
+      code: '<div><Route path="/admin/literal/path/with/prefix" /></div>',
+      errors: errorMessage(),
+    },
+    {
+      code: '<div><Route path={`/admin/template/path/with/prefix`} /></div>',
+      errors: errorMessage(),
+    },
+    {
+      code: '<Route path="/literal/path/with/admin/prefix" />',
+      errors: errorMessage(),
+    },
+    {
+      code: '<Route path={`/template/path/with/admin/prefix`} />',
+      errors: errorMessage(),
+    },
+    {
+      code: '<Route path="/literal/path/with/prefix/admin" />',
+      errors: errorMessage(),
+    },
+    {
+      code: '<Route path={`/template/path/with/prefix/admin`} />',
+      errors: errorMessage(),
+    },
+    {
+      code: '<Route path="/admin" />',
+      errors: errorMessage(),
+    },
+    {
+      code: '<Route path={`/admin`} />',
+      errors: errorMessage(),
+    },
+  ],
+});


### PR DESCRIPTION
## Description

We are on our way to remove the path prefix `/admin` as part of Unified Admin project.
The prefix is being extracted into a global state/variable to be shared across web as much as we can.
In the meantime, we draw the line with this rule so we don't keep adding routes with the hardcoded prefix.

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [ ] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [x] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
