### PR TITLE
Remove lines around comment rule in prettier eslint-plugins

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Removed `lines-around-comment` rule, let prettier handle formatting of comments. [[#319](https://github.com/Shopify/web-configs/pull/319)]
 
 ## 41.0.1 - 2021-12-02
 

--- a/packages/eslint-plugin/lib/config/prettier.js
+++ b/packages/eslint-plugin/lib/config/prettier.js
@@ -13,15 +13,6 @@ module.exports = {
     'prefer-arrow-callback': 'off',
     'arrow-body-style': 'off',
 
-    // Special rule for 'lines-around-comment'
-    // https://github.com/prettier/eslint-config-prettier/blob/984de70e8c6b57684b444283561019389ccebd11/README.md#lines-around-comment
-    'lines-around-comment': [
-      'error',
-      {
-        beforeBlockComment: true,
-      },
-    ],
-
     // Special rule for 'no-unexpected-multiline'
     // https://github.com/prettier/eslint-config-prettier/blob/5399175c37466747aae9d407021dffec2c169c8b/README.md#no-unexpected-multiline
     'no-unexpected-multiline': 'error',


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request.

If this fixes an existing issue, please include the issue number.
-->

As said in [this PR](https://github.com/Shopify/web/pull/56144). We have discussed and decided that the rule `lines-around-comment` should no longer be enforced upon us because of known typescript issues such as [typescript-eslint/typescript-eslint#1150](https://github.com/typescript-eslint/typescript-eslint/issues/1150). We believe that we should stay consistent with this rule all across `shopify` and should remove this rule from the `eslint-plugins`.

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ]  Patch: Bug (non-breaking change which fixes an issue)
- [x] eslint-plugin Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
