### PR TITLE
Remove broken image logo link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,3 @@ The release process currently involves some manual steps to complete. Once your 
 ## License
 
 MIT &copy; [Shopify](https://shopify.com/), see [LICENSE.md](LICENSE.md) for details.
-
-<a href="http://www.shopify.com/"><img src="https://cdn.shopify.com/assets2/brand-assets/shopify-logo-main-8ee1e0052baf87fd9698ceff7cbc01cc36a89170212ad227db3ff2706e89fd04.svg" alt="Shopify" width="200" /></a>


### PR DESCRIPTION
## Description

Image link was 404. Other public repos do not have this link.

## Type of change

Removed link.

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
