### PR TITLE
Add `q` as allowed identifier in eslint

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -7,10 +7,6 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- ## Unreleased -->
 
-### Changed
-
-- Allow usage of `q` variable in `id-length` rule [[#329](https://github.com/Shopify/web-configs/pull/329)]
-
 ## 41.2.0 - 2022-03-07
 
 ### Changed

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+<!-- ## Unreleased 
+
+### Changed
+
+- Allow usage of `q` variable in `id-length` rule [[#329](https://github.com/Shopify/web-configs/pull/329)]
+
+-->
 
 ## 41.2.0 - 2022-03-07
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,13 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased 
+<!-- ## Unreleased -->
 
 ### Changed
 
 - Allow usage of `q` variable in `id-length` rule [[#329](https://github.com/Shopify/web-configs/pull/329)]
-
--->
 
 ## 41.2.0 - 2022-03-07
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Allow usage of `q` variable in `id-length` rule [[#329](https://github.com/Shopify/web-configs/pull/329)]
 
 ## 41.2.0 - 2022-03-07
 

--- a/packages/eslint-plugin/lib/config/rules/stylistic-issues.js
+++ b/packages/eslint-plugin/lib/config/rules/stylistic-issues.js
@@ -54,7 +54,7 @@ module.exports = {
     {
       min: 2,
       properties: 'always',
-      exceptions: ['x', 'y', 'i', 'j', 't', '_', '$'],
+      exceptions: ['x', 'y', 'i', 'j', 't', 'q', '_', '$'],
     },
   ],
   // Require identifiers to match the provided regular expression


### PR DESCRIPTION
## Description

`q` is a common identifier for a search query param, and it used in many apps across Shopify. 

Previously, we had to do this:

```js
// eslint-disable-next-line
const { data, loading, error } = useSearchPackages({ q: "foo" })
```

This patch makes it less painful to use `q` in Javascript-land.

## Type of change

- [ ] @shopify/eslint-plugin Patch: Bug (non-breaking change which fixes an issue)
- [x] @shopify/eslint-plugin Minor: New feature (non-breaking change which adds functionality)
- [ ] @shopify/eslint-plugin Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
