### PR TITLE
Run prettier over repo md/json/yml files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 node_modules
-*.md
+packages/eslint-plugin/docs/rules/**/*.md
 package.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[comment]: # (NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead)
+[comment]: # 'NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead'
 
 # Web Configs
 
@@ -12,20 +12,20 @@ This repo is managed as a monorepo that is composed of many npm packages, where 
 
 ### Package Index
 
-| Name | NPM | Size |
-| ------- | --- | --- |
-| [babel-preset](packages/babel-preset) | [![npm version](https://badge.fury.io/js/%40shopify%2Fbabel-preset.svg)](https://badge.fury.io/js/%40shopify%2Fbabel-preset) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/babel-preset.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/babel-preset.svg) |
+| Name                                                | NPM                                                                                                                                        | Size                                                                                                                                                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [babel-preset](packages/babel-preset)               | [![npm version](https://badge.fury.io/js/%40shopify%2Fbabel-preset.svg)](https://badge.fury.io/js/%40shopify%2Fbabel-preset)               | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/babel-preset.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/babel-preset.svg)               |
 | [browserslist-config](packages/browserslist-config) | [![npm version](https://badge.fury.io/js/%40shopify%2Fbrowserslist-config.svg)](https://badge.fury.io/js/%40shopify%2Fbrowserslist-config) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/browserslist-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/browserslist-config.svg) |
-| [eslint-plugin](packages/eslint-plugin) | [![npm version](https://badge.fury.io/js/%40shopify%2Feslint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Feslint-plugin) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/eslint-plugin.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/eslint-plugin.svg) |
-| [images](packages/images) | [![npm version](https://badge.fury.io/js/%40shopify%2Fimages.svg)](https://badge.fury.io/js/%40shopify%2Fimages) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/images.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/images.svg) |
-| [postcss-plugin](packages/postcss-plugin) | [![npm version](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/postcss-plugin.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/postcss-plugin.svg) |
-| [prettier-config](packages/prettier-config) | [![npm version](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)](https://badge.fury.io/js/%40shopify%2Fprettier-config) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg) |
-| [stylelint-plugin](packages/stylelint-plugin) | [![npm version](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/stylelint-plugin.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/stylelint-plugin.svg) |
-| [typescript-configs](packages/typescript-configs) | [![npm version](https://badge.fury.io/js/%40shopify%2Ftypescript-configs.svg)](https://badge.fury.io/js/%40shopify%2Ftypescript-configs) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/typescript-configs.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/typescript-configs.svg) |
+| [eslint-plugin](packages/eslint-plugin)             | [![npm version](https://badge.fury.io/js/%40shopify%2Feslint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Feslint-plugin)             | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/eslint-plugin.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/eslint-plugin.svg)             |
+| [images](packages/images)                           | [![npm version](https://badge.fury.io/js/%40shopify%2Fimages.svg)](https://badge.fury.io/js/%40shopify%2Fimages)                           | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/images.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/images.svg)                           |
+| [postcss-plugin](packages/postcss-plugin)           | [![npm version](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fpostcss-plugin)           | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/postcss-plugin.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/postcss-plugin.svg)           |
+| [prettier-config](packages/prettier-config)         | [![npm version](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)](https://badge.fury.io/js/%40shopify%2Fprettier-config)         | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)         |
+| [stylelint-plugin](packages/stylelint-plugin)       | [![npm version](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin.svg)](https://badge.fury.io/js/%40shopify%2Fstylelint-plugin)       | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/stylelint-plugin.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/stylelint-plugin.svg)       |
+| [typescript-configs](packages/typescript-configs)   | [![npm version](https://badge.fury.io/js/%40shopify%2Ftypescript-configs.svg)](https://badge.fury.io/js/%40shopify%2Ftypescript-configs)   | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/typescript-configs.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/typescript-configs.svg)   |
 
 ## Contribution
 
-This repository has a CLA-Bot running which will ask contributors to sign a Contributor License Agreement (CLA). 
+This repository has a CLA-Bot running which will ask contributors to sign a Contributor License Agreement (CLA).
 
 Shopify has also adopted a Code of Conduct that we expect contributors to adhere to. Please read the [full text](./CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
@@ -65,11 +65,11 @@ More usage instructions on the `tophat` command can be [found here](https://gith
 
 #### Documentation
 
-If your change affects the public API of any packages within this repository (i.e. adding or changing arguments to a function, adding a new function, changing the return value, etc), please ensure the documentation is updated,  and a changelog is added to reflect this. Documentation is in the `README.md` files of each package. If further documentation is needed please communicate via a GitHub issue.
+If your change affects the public API of any packages within this repository (i.e. adding or changing arguments to a function, adding a new function, changing the return value, etc), please ensure the documentation is updated, and a changelog is added to reflect this. Documentation is in the `README.md` files of each package. If further documentation is needed please communicate via a GitHub issue.
 
 #### Testing
 
-The packages in this repository are used in mission-critical production scenarios. As such, we do not merge any untested code. 
+The packages in this repository are used in mission-critical production scenarios. As such, we do not merge any untested code.
 
 To run the full test suite, simply run `dev test` or `yarn test`.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "test": "jest",
-    "lint": "eslint '**/*.{js,jsx,ts,tsx}'",
+    "lint": "eslint '**/*.{js,jsx,ts,tsx}' && prettier './**/*.{md,json,yml}' --check",
     "generate": "plop",
     "generate:package": "plop package && yarn plop docs",
     "release": "changeset publish",

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -34,7 +34,6 @@
 
 - Updated `@babel/runtime`, `@babel/preset-env`, and `@babel/core`. [[#273](https://github.com/Shopify/web-configs/pull/273)]
 
-
 ## 24.1.0 - 2021-07-07
 
 ### Added
@@ -264,7 +263,6 @@ module.exports = {
   - `babel-plugin-transform-object-rest-spread` 6.23.0 => 6.26.0
   - `babel-preset-env` 1.5.2 => 1.7.0.
 
-
 ### Chore
 
 - Switch from Circle CI to Travis.
@@ -318,7 +316,6 @@ module.exports = {
 - `shopify/react` now includes a `hot` option to enable plugins related to hot reloading (`react-hot-loader` and `react-pure-to-component`).
 - `shopify/react` now includes plugins in development that add additional information for debugging purposes, and plugins in production that offer some performance optimizations.
 - `shopify/web` now accepts an additional option, `browsers` (an array of [`browserslist`](https://github.com/ai/browserslist) strings) which specifies what browsers to transpile for (defaults to the browsers supported by Shopify’s admin).
-
 
 ### Changed
 

--- a/packages/babel-preset/README.md
+++ b/packages/babel-preset/README.md
@@ -39,9 +39,7 @@ The `@shopify/babel-preset` preset is designed to be a common import that can be
 ```json
 {
   "babel": {
-    "presets": [
-      ["@shopify/babel-preset", {"typescript": true}]
-    ]
+    "presets": [["@shopify/babel-preset", {"typescript": true}]]
   }
 }
 ```
@@ -117,4 +115,3 @@ When spreading props, use inline object with spread elements directly instead of
 This option when `true` will enable the `@babel/plugin-transform-react-constant-elements` plugin in production mode.
 
 [Documentation](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements)
-    

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -52,11 +52,10 @@
 | `eslint-plugin-react-hooks`        | `^4.2.0`    | `^4.3.0`    |
 | `eslint-plugin-sort-class-members` | `^1.11.0`   | `^1.14.0`   |
 
-
 ### Changed
 
-- Update env and ecmaVersion to '2021' in `esnext` and`typescript` presets to support modern language features. [[#296](https://github.com/Shopify/web-configs/pull/296), [#304](https://github.com/Shopify/web-configs/pull/304)] 
-- Remove configuring `parserOptions` from the `jest` preset as this handled by the the es5/esnext/typescript presets. [[#304](https://github.com/Shopify/web-configs/pull/304)] 
+- Update env and ecmaVersion to '2021' in `esnext` and`typescript` presets to support modern language features. [[#296](https://github.com/Shopify/web-configs/pull/296), [#304](https://github.com/Shopify/web-configs/pull/304)]
+- Remove configuring `parserOptions` from the `jest` preset as this handled by the the es5/esnext/typescript presets. [[#304](https://github.com/Shopify/web-configs/pull/304)]
 - Removed dependency on `merge` by replacing usage with object spread. [[#308](https://github.com/Shopify/web-configs/pull/308)]
 
 ## 40.5.0 - 2021-11-18
@@ -125,17 +124,17 @@
 
 - Updated `eslint-plugin` plugins and removed support for `eslint@6`. [[#194](https://github.com/Shopify/web-foundation/pull/194)]
 
-| Package                                   | Old version | New version |
-| ----------------------------------------- | ----------- | ----------- |
-| `eslint-config-prettier`                  | `6.14.0`    | `7.2.0`     |
-| `eslint-plugin-jest-formatting`           | `2.0.0`     | `2.0.1`     |
-| `eslint-plugin-promise`                   | `4.2.1`     | `4.3.1`     |
-| `eslint-plugin-jest`                      | `24.1.0`    | `24.1.3`    |
-| `eslint-plugin-react`                     | `7.21.5`    | `7.22.0`    |
-| `eslint-plugin-sort-class-members`        | `1.8.0`     | `1.9.0`     |
-| `@typescript-eslint/eslint-plugin`        | `4.1.0`     | `4.15.0`    |
-| `@typescript-eslint/parser`               | `4.1.0`     | `4.15.0`    |
-| `change-case`                             | `4.1.0`     | `4.1.2`     |
+| Package                            | Old version | New version |
+| ---------------------------------- | ----------- | ----------- |
+| `eslint-config-prettier`           | `6.14.0`    | `7.2.0`     |
+| `eslint-plugin-jest-formatting`    | `2.0.0`     | `2.0.1`     |
+| `eslint-plugin-promise`            | `4.2.1`     | `4.3.1`     |
+| `eslint-plugin-jest`               | `24.1.0`    | `24.1.3`    |
+| `eslint-plugin-react`              | `7.21.5`    | `7.22.0`    |
+| `eslint-plugin-sort-class-members` | `1.8.0`     | `1.9.0`     |
+| `@typescript-eslint/eslint-plugin` | `4.1.0`     | `4.15.0`    |
+| `@typescript-eslint/parser`        | `4.1.0`     | `4.15.0`    |
+| `change-case`                      | `4.1.0`     | `4.1.2`     |
 
 ## 39.0.4 - 2021-01-13
 
@@ -160,15 +159,14 @@
 
 - Updated `eslint-plugin` plugins. [[#194](https://github.com/Shopify/web-foundation/pull/194)]
 
-| Package                            | Old version | New version |
-| ---------------------------------- | ----------- | ----------- |
-| `eslint-config-prettier`           | `6.11.0`    | `6.14.0`    |
-| `eslint-plugin-jsx-a11y`           | `6.3.1`     | `6.4.1`     |
-| `eslint-plugin-import`             | `2.22.0`    | `2.22.1`    |
-| `eslint-plugin-jest`               | `24.0.0`    | `24.1.0`    |
-| `eslint-plugin-react`              | `7.20.6`    | `7.21.5`    |
-| `eslint-plugin-react-hooks`        | `4.1.1`     | `4.1.2`     |
-
+| Package                     | Old version | New version |
+| --------------------------- | ----------- | ----------- |
+| `eslint-config-prettier`    | `6.11.0`    | `6.14.0`    |
+| `eslint-plugin-jsx-a11y`    | `6.3.1`     | `6.4.1`     |
+| `eslint-plugin-import`      | `2.22.0`    | `2.22.1`    |
+| `eslint-plugin-jest`        | `24.0.0`    | `24.1.0`    |
+| `eslint-plugin-react`       | `7.20.6`    | `7.21.5`    |
+| `eslint-plugin-react-hooks` | `4.1.1`     | `4.1.2`     |
 
 ## 39.0.0 - 2020-09-17
 
@@ -192,7 +190,6 @@
 | `eslint-plugin-react-hooks`        | `4.0.2`     | `4.1.1`     |
 | `eslint-plugin-sort-class-members` | `1.7.0`     | `1.8.0`     |
 
-
 ## 38.0.0
 
 ### Added
@@ -207,16 +204,15 @@
 
 - Removal of `@typescript-eslint/ban-ts-ignore` for `@typescript-eslint/ban-ts-comment`. Please update your ignore statements.
 
-
 ## 37.0.0 - 2020-05-19
 
 ### Added
 
 The following new rules were introduced. More information can be found. [[#157](https://github.com/Shopify/web-foundation/pull/157)]
+
 - [`react/jsx-no-script-url`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-script-url.md)
 
 Facebook improved the `eslint-plugin-react-hooks` plugin. We may have to update the dependencies of some hooks.
-
 
 #### Updated Plugins
 
@@ -296,6 +292,7 @@ rules: {
 ### Added
 
 The followiing new rules were introduced in `eslint@6.7.0`. More information can be found on the [eslint blog](https://eslint.org/blog/2019/11/eslint-v6.7.0-released).
+
 - [`grouped-accessor-pairs`](https://eslint.org/docs/rules/grouped-accessor-pairs)
 - [`no-constructor-return`](https://eslint.org/docs/rules/no-constructor-return)
 - [`no-dupe-else-if`](https://eslint.org/docs/rules/no-dupe-else-if)
@@ -384,12 +381,10 @@ _Example config for react with typescript projects:_
 
 - **Note** If using the `plugin:shopify/typescript-type-checking` augmented config, you must specify a path to your tsconfig.json file in the "project" property of "parserOptions"
 
-
 ### Added
 
 - `jest/no-standalone-expect` Prevents `expect` statements outside of a `test` or `it` block. [[#368](https://github.com/Shopify/eslint-plugin-shopify/pull/368)]
 - `jest/no-expect-resolves` Avoid using `expect().resolves`. [[#370](https://github.com/Shopify/eslint-plugin-shopify/pull/370)]
-
 
 ## 30.0.1 - 2019-06-24
 
@@ -448,7 +443,7 @@ _Example config for react with typescript projects:_
 
 ### Changed
 
-* Reverted a previous update from `eslint-plugin-typescript` to `@typescript-eslint/eslint-plugin`. If you have any rules defined under the `@typescript-eslint` namespace, you will need to change those to use the older `typescript` namespace.
+- Reverted a previous update from `eslint-plugin-typescript` to `@typescript-eslint/eslint-plugin`. If you have any rules defined under the `@typescript-eslint` namespace, you will need to change those to use the older `typescript` namespace.
 
   For example:
 
@@ -470,32 +465,32 @@ _Example config for react with typescript projects:_
 
 ### Fixed
 
-* `shopify/restrict-full-import` "empty" array pattern (eg: `const [, bar] = foo` errors. [[#243](https://github.com/Shopify/eslint-plugin-shopify/pull/243)]
-* Optimized `shopify/images/no-direct-imports` to be much faster in the common case. [[#247](https://github.com/Shopify/eslint-plugin-shopify/pull/247)]
-* `shopify/react-hooks-strict-return` from crashing when a hook returns undefined. [[#251](https://github.com/Shopify/eslint-plugin-shopify/pull/251)]
+- `shopify/restrict-full-import` "empty" array pattern (eg: `const [, bar] = foo` errors. [[#243](https://github.com/Shopify/eslint-plugin-shopify/pull/243)]
+- Optimized `shopify/images/no-direct-imports` to be much faster in the common case. [[#247](https://github.com/Shopify/eslint-plugin-shopify/pull/247)]
+- `shopify/react-hooks-strict-return` from crashing when a hook returns undefined. [[#251](https://github.com/Shopify/eslint-plugin-shopify/pull/251)]
 
 ### Added
 
-* updated `eslint-plugin-import` to version `22.4.1` which introduces the [`no-unused-modules`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unused-modules.md) rule.
-* updated `eslint-plugin-jest` to version `22.4.1` which introduces the [`no-empty-title`](https://github.com/jest-community/eslint-plugin-jest/commit/c793b7a) rule.
-* `shopify/react-hooks-strict-return` Restrict the number of returned items from React hooks. [[#237](https://github.com/Shopify/eslint-plugin-shopify/pull/237)]
+- updated `eslint-plugin-import` to version `22.4.1` which introduces the [`no-unused-modules`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unused-modules.md) rule.
+- updated `eslint-plugin-jest` to version `22.4.1` which introduces the [`no-empty-title`](https://github.com/jest-community/eslint-plugin-jest/commit/c793b7a) rule.
+- `shopify/react-hooks-strict-return` Restrict the number of returned items from React hooks. [[#237](https://github.com/Shopify/eslint-plugin-shopify/pull/237)]
 
 ### Removed
 
-* turned off `node/no-extraneous-require` because it duplicates reported violations from `import/no-extraneous-dependencies`. [[#240](https://github.com/Shopify/eslint-plugin-shopify/pull/240)]
+- turned off `node/no-extraneous-require` because it duplicates reported violations from `import/no-extraneous-dependencies`. [[#240](https://github.com/Shopify/eslint-plugin-shopify/pull/240)]
 
 ## 27.0.1 - 2019-04-10
 
 ### Changed
 
-* `shopify/jest/no-if` no longer considers if statements in describe blocks as invalid. [[#235](https://github.com/Shopify/eslint-plugin-shopify/pull/235)]
+- `shopify/jest/no-if` no longer considers if statements in describe blocks as invalid. [[#235](https://github.com/Shopify/eslint-plugin-shopify/pull/235)]
 
 ### Removed
 
-* turned off `consistent-return`. [[#236](https://github.com/Shopify/eslint-plugin-shopify/pull/236)]
-* turned off `react/jsx-no-bind`. [[#239](https://github.com/Shopify/eslint-plugin-shopify/pull/239)]
-* turned off `babel/camelcase` in typescript config because it overlaps with `@typescript-eslint/camelcase`. [[#238](https://github.com/Shopify/eslint-plugin-shopify/pull/238)]
-* `shopify/jest/no-if` no longer considers if statements in describe blocks as invalid. [[#235](https://github.com/Shopify/eslint-plugin-shopify/pull/235)]
+- turned off `consistent-return`. [[#236](https://github.com/Shopify/eslint-plugin-shopify/pull/236)]
+- turned off `react/jsx-no-bind`. [[#239](https://github.com/Shopify/eslint-plugin-shopify/pull/239)]
+- turned off `babel/camelcase` in typescript config because it overlaps with `@typescript-eslint/camelcase`. [[#238](https://github.com/Shopify/eslint-plugin-shopify/pull/238)]
+- `shopify/jest/no-if` no longer considers if statements in describe blocks as invalid. [[#235](https://github.com/Shopify/eslint-plugin-shopify/pull/235)]
 
 ## 27.0.0 - 2019-04-08
 
@@ -505,11 +500,11 @@ _Example config for react with typescript projects:_
 
 #### Breaking Changes
 
-* `shopify/jquery-dollar-sign-reference` has been removed.
-* The `eslint-comments` ruleset has been removed and is now enabled by default as part of core - if you're using `es5`, `esnext`, `react` or `typescript` then you can remove the reference to `eslint-comments`.
-* The `ava`, `mocha`, `jquery` and `lodash` rulesets have been removed as these tools are are not commonly used at Shopify.
-* The `typescript-react` and `typescript-prettier` rulesets have been removed. Replace `["plugin:shopify/typescript-react"]` with `["plugin:shopify/typescript", "plugin:shopify/react"]` and replace`["plugin:shopify/typescript-prettier"]`  with `["plugin:shopify/prettier"]`
-* Updated from `eslint-plugin-typescript` to `@typescript-eslint/eslint-plugin`. If you have any rules defined under the `typescript` namespace, you will need to change those to use the new `@typescript-eslint` namespace.
+- `shopify/jquery-dollar-sign-reference` has been removed.
+- The `eslint-comments` ruleset has been removed and is now enabled by default as part of core - if you're using `es5`, `esnext`, `react` or `typescript` then you can remove the reference to `eslint-comments`.
+- The `ava`, `mocha`, `jquery` and `lodash` rulesets have been removed as these tools are are not commonly used at Shopify.
+- The `typescript-react` and `typescript-prettier` rulesets have been removed. Replace `["plugin:shopify/typescript-react"]` with `["plugin:shopify/typescript", "plugin:shopify/react"]` and replace`["plugin:shopify/typescript-prettier"]` with `["plugin:shopify/prettier"]`
+- Updated from `eslint-plugin-typescript` to `@typescript-eslint/eslint-plugin`. If you have any rules defined under the `typescript` namespace, you will need to change those to use the new `@typescript-eslint` namespace.
 
   For example:
 
@@ -526,17 +521,17 @@ _Example config for react with typescript projects:_
     "@typescript-eslint/restrict-plus-operands": "error"
   }
   ```
+
   More information on this change can be found [in this eslint blog post](https://eslint.org/blog/2019/01/future-typescript-eslint]).
 
 #### Added
 
-* `shopify/jest/no-if`. [[#232](https://github.com/Shopify/eslint-plugin-shopify/pull/232)]
+- `shopify/jest/no-if`. [[#232](https://github.com/Shopify/eslint-plugin-shopify/pull/232)]
 
 Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules.html) to learn more about the following rules.
 
-* `'react-hooks/rules-of-hooks': 'error'`   // Only use Hooks at the top level of a React functional component or from within another custom hook.
-* `'react-hooks/exhaustive-deps': 'error'`   // Checks for missing useEffect dependencies
-
+- `'react-hooks/rules-of-hooks': 'error'` // Only use Hooks at the top level of a React functional component or from within another custom hook.
+- `'react-hooks/exhaustive-deps': 'error'` // Checks for missing useEffect dependencies
 
 #### Updated Plugins
 
@@ -564,63 +559,64 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 #### Removed Plugins
 
-| Package |
-| ------- |
-| eslint-plugin-mocha |
-| eslint-plugin-ava |
-| eslint-plugin-flowtype |
+| Package                   |
+| ------------------------- |
+| eslint-plugin-mocha       |
+| eslint-plugin-ava         |
+| eslint-plugin-flowtype    |
 | eslint-plugin-chai-expect |
-| eslint-plugin-lodash |
-| eslint-plugin-jquery |
+| eslint-plugin-lodash      |
+| eslint-plugin-jquery      |
 
 ### Changed
 
-* `jest/no-vague-titles` added `every` and `descriptive` as vague words. [[#221](https://github.com/Shopify/eslint-plugin-shopify/pull/221)]
+- `jest/no-vague-titles` added `every` and `descriptive` as vague words. [[#221](https://github.com/Shopify/eslint-plugin-shopify/pull/221)]
 
 ## 26.3.0 - 2019-02-21
 
 ### Added
 
-* Updated `eslint-plugin-react` and enabled `react/jsx-fragments` rule to prefer using `<>` over `<React.Fragment>` when defining fragments. [[#223](https://github.com/Shopify/eslint-plugin-shopify/pull/223)]
+- Updated `eslint-plugin-react` and enabled `react/jsx-fragments` rule to prefer using `<>` over `<React.Fragment>` when defining fragments. [[#223](https://github.com/Shopify/eslint-plugin-shopify/pull/223)]
 
 ## 26.2.0 - 2019-02-14
 
 ### Added
 
-* `images-no-direct-imports`. [[#219](https://github.com/Shopify/eslint-plugin-shopify/pull/219)]
+- `images-no-direct-imports`. [[#219](https://github.com/Shopify/eslint-plugin-shopify/pull/219)]
 
 ## 26.1.2 - 2019-01-02
 
 ### Fixed
 
-* `jest/no-vague-titles` no longer flags when the word `call` is used. [[#203](https://github.com/Shopify/eslint-plugin-shopify/pull/203)]
-* Update `eslint-plugin-prettier` to 3.0.1 so it does not crash when given an unparsable file. [[#212](https://github.com/Shopify/eslint-plugin-shopify/pull/212)]
+- `jest/no-vague-titles` no longer flags when the word `call` is used. [[#203](https://github.com/Shopify/eslint-plugin-shopify/pull/203)]
+- Update `eslint-plugin-prettier` to 3.0.1 so it does not crash when given an unparsable file. [[#212](https://github.com/Shopify/eslint-plugin-shopify/pull/212)]
 
 ### Changed
 
-* `jest/no-vague-titles` added `should` and `properly` to vague rules and new configuration to `allow` words. [[#208](https://github.com/Shopify/eslint-plugin-shopify/pull/208)]
+- `jest/no-vague-titles` added `should` and `properly` to vague rules and new configuration to `allow` words. [[#208](https://github.com/Shopify/eslint-plugin-shopify/pull/208)]
 
 ## 26.1.1 - 2018-10-31
 
 ### Fixed
 
-* `typescript-eslint-parser` pinned at `20.0.0` to avoid [a known issue](https://github.com/eslint/typescript-eslint-parser/issues/535). [[#201](https://github.com/Shopify/eslint-plugin-shopify/pull/201)]
+- `typescript-eslint-parser` pinned at `20.0.0` to avoid [a known issue](https://github.com/eslint/typescript-eslint-parser/issues/535). [[#201](https://github.com/Shopify/eslint-plugin-shopify/pull/201)]
 
 ## 26.1.0 - 2018-10-30
 
 ### Added
 
-* `shopify/no-ancestor-directory-import`. [[#149](https://github.com/Shopify/eslint-plugin-shopify/pull/149)]
+- `shopify/no-ancestor-directory-import`. [[#149](https://github.com/Shopify/eslint-plugin-shopify/pull/149)]
 
 ### Fixed
 
-* Set TypeScript parser only on TS files. This makes sure you can extend from the typescript and react configs in either order. Previously you had to make sure typescript came first to avoid using the babel-eslint parser on typescript files. Now we suggest to extend from typescript, and then react to ensure some rules some JSX rules don't get inadventently disabled. [[#200](https://github.com/Shopify/eslint-plugin-shopify/pull/200)]
+- Set TypeScript parser only on TS files. This makes sure you can extend from the typescript and react configs in either order. Previously you had to make sure typescript came first to avoid using the babel-eslint parser on typescript files. Now we suggest to extend from typescript, and then react to ensure some rules some JSX rules don't get inadventently disabled. [[#200](https://github.com/Shopify/eslint-plugin-shopify/pull/200)]
 
 ## 26.0.0 - 2018-10-26
 
 ### Added
 
-* `shopify/eslint-comments` plugin with [eslint-plugin-eslint-comments](https://www.npmjs.com/package/eslint-plugin-eslint-comments) rules:
+- `shopify/eslint-comments` plugin with [eslint-plugin-eslint-comments](https://www.npmjs.com/package/eslint-plugin-eslint-comments) rules:
+
   - `eslint-comments/disable-enable-pair`,
   - `eslint-comments/no-aggregating-enable`
   - `eslint-comments/no-duplicate-disable`
@@ -630,181 +626,180 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
   - `eslint-comments/no-restricted-disable` (disabled)
   - `eslint-comments/no-use` (disabled)
 
-* `shopify/jest/no-snapshots`. [[#182](https://github.com/Shopify/eslint-plugin-shopify/pull/182)]
+- `shopify/jest/no-snapshots`. [[#182](https://github.com/Shopify/eslint-plugin-shopify/pull/182)]
 
 ### Changed
 
-* Updated `plugin:shopify/prettier`, `plugin:shopify/react`, and `plugin:shopify/typescript` to use `overrides`. [[#173](https://github.com/Shopify/eslint-plugin-shopify/pull/173)]
-* Updated `import/order` rule to enforce ordering of internal, parent and sibling imports. [[#189](https://github.com/Shopify/eslint-plugin-shopify/pull/189)]
-* Updated `func-style` rule to allow arrow functions. [[#188](https://github.com/Shopify/eslint-plugin-shopify/pull/188)]
+- Updated `plugin:shopify/prettier`, `plugin:shopify/react`, and `plugin:shopify/typescript` to use `overrides`. [[#173](https://github.com/Shopify/eslint-plugin-shopify/pull/173)]
+- Updated `import/order` rule to enforce ordering of internal, parent and sibling imports. [[#189](https://github.com/Shopify/eslint-plugin-shopify/pull/189)]
+- Updated `func-style` rule to allow arrow functions. [[#188](https://github.com/Shopify/eslint-plugin-shopify/pull/188)]
 
 ### Fixed
 
-* Rolling back `eslint-plugin-graphql` to `2.1.0-0` for multiple schema support. [[#195](https://github.com/Shopify/eslint-plugin-shopify/pull/195)]
+- Rolling back `eslint-plugin-graphql` to `2.1.0-0` for multiple schema support. [[#195](https://github.com/Shopify/eslint-plugin-shopify/pull/195)]
 
 ## 25.1.0 - 2018-10-01
 
 ### Changed
 
-* Updated `typescript-eslint-parser` dependency to version 19.0.2 to support `typescript-estree`. [[#176](https://github.com/Shopify/eslint-plugin-shopify/pull/176)]
+- Updated `typescript-eslint-parser` dependency to version 19.0.2 to support `typescript-estree`. [[#176](https://github.com/Shopify/eslint-plugin-shopify/pull/176)]
 
 ## 25.0.1 - 2018-09-25
 
 ### Fixed
 
-* Restored `typescript-prettier` config to override `prettier` plugin parser. [[#171](https://github.com/Shopify/eslint-plugin-shopify/pull/171)]
+- Restored `typescript-prettier` config to override `prettier` plugin parser. [[#171](https://github.com/Shopify/eslint-plugin-shopify/pull/171)]
 
 ## 25.0.0 - 2018-09-25
 
 ### Fixed
 
-* Updated `plugin:shopify/prettier` to enable prettier linting. [[#170](https://github.com/Shopify/eslint-plugin-shopify/pull/170)]
-* `strict-component-boundaries` now consistently uses the resolved path from the app root to perform its checks. This fixes a number of false-positives. [[#160](https://github.com/Shopify/eslint-plugin-shopify/pull/160)]
+- Updated `plugin:shopify/prettier` to enable prettier linting. [[#170](https://github.com/Shopify/eslint-plugin-shopify/pull/170)]
+- `strict-component-boundaries` now consistently uses the resolved path from the app root to perform its checks. This fixes a number of false-positives. [[#160](https://github.com/Shopify/eslint-plugin-shopify/pull/160)]
 
 ## 24.2.0 - 2018-09-21
 
 ### Added
 
-* Added `plugin:shopify/graphql` to module index. [[#168](https://github.com/Shopify/eslint-plugin-shopify/pull/168)]
+- Added `plugin:shopify/graphql` to module index. [[#168](https://github.com/Shopify/eslint-plugin-shopify/pull/168)]
 
 ### Fixed
 
-* Updated `no-vague-titles` rule to fix parsing issues in `getMethodName`. [[#167](https://github.com/Shopify/eslint-plugin-shopify/pull/167)]
+- Updated `no-vague-titles` rule to fix parsing issues in `getMethodName`. [[#167](https://github.com/Shopify/eslint-plugin-shopify/pull/167)]
 
 ## 24.1.1 - 2018-09-19
 
-* Same as `24.1.0`
+- Same as `24.1.0`
 
 ## 24.1.0 - 2018-09-19
 
 ### Added
 
-* Added `shopify/graphql` config using new `eslint-plugin-graphql` (`2.1.1.`) dependency. [[#165](https://github.com/Shopify/eslint-plugin-shopify/pull/165)]
+- Added `shopify/graphql` config using new `eslint-plugin-graphql` (`2.1.1.`) dependency. [[#165](https://github.com/Shopify/eslint-plugin-shopify/pull/165)]
 
 ## 24.0.0 - 2018-08-30
 
 ### Fixed
 
-* `plugin:shopify/flow` now disables rules checked by Flow's static analyzer. [[#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135)]
-* `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` defer missing semicolon rules to a project´s `.prettierrc`. [[#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135)]
-* Updated `strict-component-boundaries` to exclude fixture imports. [[#117](https://github.com/Shopify/eslint-plugin-shopify/pull/117)]
-* Updated `strict-component-boundaries` to exclude imports from node_modules. [[#140](https://github.com/Shopify/eslint-plugin-shopify/pull/140)]
-* Updated `jest/no-vague-titles` to support `.each` syntax. [[#148](https://github.com/Shopify/eslint-plugin-shopify/pull/148)]
+- `plugin:shopify/flow` now disables rules checked by Flow's static analyzer. [[#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135)]
+- `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` defer missing semicolon rules to a project´s `.prettierrc`. [[#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135)]
+- Updated `strict-component-boundaries` to exclude fixture imports. [[#117](https://github.com/Shopify/eslint-plugin-shopify/pull/117)]
+- Updated `strict-component-boundaries` to exclude imports from node_modules. [[#140](https://github.com/Shopify/eslint-plugin-shopify/pull/140)]
+- Updated `jest/no-vague-titles` to support `.each` syntax. [[#148](https://github.com/Shopify/eslint-plugin-shopify/pull/148)]
 
 ### Changed
 
-* Namespaced `prefer-pascal-case-enums` and `prefer-singular-enums` under `typescript`. [[#141](https://github.com/Shopify/eslint-plugin-shopify/pull/141)]
-* **Breaking:** Updated to eslint `v5.4.0`. Consuming projects must be using [supported](https://eslint.org/docs/user-guide/migrating-to-5.0.0#-nodejs-4-is-no-longer-supported) node versions, we recommend `^8.10.0`. See details on the v4 to v5 [migration guide](https://eslint.org/docs/user-guide/migrating-to-5.0.0). [[#151](https://github.com/Shopify/eslint-plugin-shopify/pull/151)]
+- Namespaced `prefer-pascal-case-enums` and `prefer-singular-enums` under `typescript`. [[#141](https://github.com/Shopify/eslint-plugin-shopify/pull/141)]
+- **Breaking:** Updated to eslint `v5.4.0`. Consuming projects must be using [supported](https://eslint.org/docs/user-guide/migrating-to-5.0.0#-nodejs-4-is-no-longer-supported) node versions, we recommend `^8.10.0`. See details on the v4 to v5 [migration guide](https://eslint.org/docs/user-guide/migrating-to-5.0.0). [[#151](https://github.com/Shopify/eslint-plugin-shopify/pull/151)]
 
 ### Added
 
-* `shopify/prefer-singular-enums`. [[#132](https://github.com/Shopify/eslint-plugin-shopify/pull/132)]
-* `shopify/react-no-multiple-render-methods`. [[#134](https://github.com/Shopify/eslint-plugin-shopify/pull/134)]
+- `shopify/prefer-singular-enums`. [[#132](https://github.com/Shopify/eslint-plugin-shopify/pull/132)]
+- `shopify/react-no-multiple-render-methods`. [[#134](https://github.com/Shopify/eslint-plugin-shopify/pull/134)]
 
-* New eslint rules and plugins rules. [[#151](https://github.com/Shopify/eslint-plugin-shopify/pull/151)]
-  * [`max-classes-per-file`](https://eslint.org/docs/rules/max-classes-per-file) (disabled)
-  * [`no-self-assign`](https://eslint.org/docs/rules/no-self-assign)
-  * [`require-unicode-regexp`](https://eslint.org/docs/rules/require-unicode-regexp) (disabled)
-  * [`no-async-promise-executor`](https://eslint.org/docs/rules/no-async-promise-executor)
-  * [`no-misleading-character-class`](https://eslint.org/docs/rules/no-misleading-character-class)
-  * [`require-atomic-updates`](https://eslint.org/docs/rules/require-atomic-updates)
-  * [`lines-between-class-members`](https://eslint.org/docs/rules/lines-between-class-members)
-  * [`max-lines-per-function`](https://eslint.org/docs/rules/max-lines-per-function) (disabled)
-  * [`multiline-comment-style`](https://eslint.org/docs/rules/multiline-comment-style) (disabled)
-  * [`prefer-object-spread`](https://eslint.org/docs/rules/prefer-object-spread)
-  * [`import/no-self-import`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-self-import.md)
-  * [`import/no-cycle`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-cycle.md)
-  * [`import/no-relative-parent-imports`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-relative-parent-imports.md)
-  * [`jest/expect-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/expect-expect.md)
-  * [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-jasmine-globals.md)
-  * [`jest/prefer-inline-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-inline-snapshots.md) (disabled)
-  * [`jest/no-test-return-statement`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-test-return-statement.md)
-  * [`node/prefer-global/buffer`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/buffer.md)
-  * [`node/prefer-global/console`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/console.md)
-  * [`node/prefer-global/process`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/process.md0)
-  * [`node/prefer-global/url-search-params`](https://github.com/mysticatea/eslint-plugin-node/blob/master/lib/rules/prefer-global/url-search-params.js)
-  * [`node/prefer-global/url`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/url.md)
-  * [`node/no-unsupported-features/es-builtins`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-builtins.md) (disabled)
-  * [`node/no-unsupported-features/es-syntax`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-syntax.md) (disabled)
-  * [`node/no-unsupported-features/node-builtins`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/node-builtins.md)
-  * [`react/no-unsafe`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unsafe.md)
-  * [`react/jsx-props-no-multi-spaces`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-multi-spaces.md)
-  * [`typescript/no-inferrable-types`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-inferrable-types.md)
-  * [`typescript/no-var-requires`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-var-requires.md)
-
+- New eslint rules and plugins rules. [[#151](https://github.com/Shopify/eslint-plugin-shopify/pull/151)]
+  - [`max-classes-per-file`](https://eslint.org/docs/rules/max-classes-per-file) (disabled)
+  - [`no-self-assign`](https://eslint.org/docs/rules/no-self-assign)
+  - [`require-unicode-regexp`](https://eslint.org/docs/rules/require-unicode-regexp) (disabled)
+  - [`no-async-promise-executor`](https://eslint.org/docs/rules/no-async-promise-executor)
+  - [`no-misleading-character-class`](https://eslint.org/docs/rules/no-misleading-character-class)
+  - [`require-atomic-updates`](https://eslint.org/docs/rules/require-atomic-updates)
+  - [`lines-between-class-members`](https://eslint.org/docs/rules/lines-between-class-members)
+  - [`max-lines-per-function`](https://eslint.org/docs/rules/max-lines-per-function) (disabled)
+  - [`multiline-comment-style`](https://eslint.org/docs/rules/multiline-comment-style) (disabled)
+  - [`prefer-object-spread`](https://eslint.org/docs/rules/prefer-object-spread)
+  - [`import/no-self-import`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-self-import.md)
+  - [`import/no-cycle`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-cycle.md)
+  - [`import/no-relative-parent-imports`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-relative-parent-imports.md)
+  - [`jest/expect-expect`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/expect-expect.md)
+  - [`jest/no-jasmine-globals`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-jasmine-globals.md)
+  - [`jest/prefer-inline-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-inline-snapshots.md) (disabled)
+  - [`jest/no-test-return-statement`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-test-return-statement.md)
+  - [`node/prefer-global/buffer`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/buffer.md)
+  - [`node/prefer-global/console`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/console.md)
+  - [`node/prefer-global/process`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/process.md0)
+  - [`node/prefer-global/url-search-params`](https://github.com/mysticatea/eslint-plugin-node/blob/master/lib/rules/prefer-global/url-search-params.js)
+  - [`node/prefer-global/url`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/prefer-global/url.md)
+  - [`node/no-unsupported-features/es-builtins`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-builtins.md) (disabled)
+  - [`node/no-unsupported-features/es-syntax`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/es-syntax.md) (disabled)
+  - [`node/no-unsupported-features/node-builtins`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-unsupported-features/node-builtins.md)
+  - [`react/no-unsafe`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unsafe.md)
+  - [`react/jsx-props-no-multi-spaces`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-multi-spaces.md)
+  - [`typescript/no-inferrable-types`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-inferrable-types.md)
+  - [`typescript/no-var-requires`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-var-requires.md)
 
 ## 23.1.0 - 2018-08-02
 
 ### Fixed
 
-* Updated `typescript-eslint-parser` dependency to version 17.0.1 in order to support TypeScript 3. [[#121](https://github.com/Shopify/eslint-plugin-shopify/pull/121)]
-* Removed default prettier configurations. `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` now defer Prettier's config to a project's `.prettierrc`. [[#121](https://github.com/Shopify/eslint-plugin-shopify/pull/121)]
+- Updated `typescript-eslint-parser` dependency to version 17.0.1 in order to support TypeScript 3. [[#121](https://github.com/Shopify/eslint-plugin-shopify/pull/121)]
+- Removed default prettier configurations. `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` now defer Prettier's config to a project's `.prettierrc`. [[#121](https://github.com/Shopify/eslint-plugin-shopify/pull/121)]
 
 ### Changed
 
-* Included `all` as a vague term for `no-vague-titles`. [[#114](https://github.com/Shopify/eslint-plugin-shopify/pull/114)]
+- Included `all` as a vague term for `no-vague-titles`. [[#114](https://github.com/Shopify/eslint-plugin-shopify/pull/114)]
 
 ## 23.0.0 - 2018-07-16
 
-* **Breaking** `eslint-plugin-shopify` will no longer install `prettier` as a dependency. Please ensure you have added `prettier` to your `package.json` if you wish to use it.
+- **Breaking** `eslint-plugin-shopify` will no longer install `prettier` as a dependency. Please ensure you have added `prettier` to your `package.json` if you wish to use it.
 
 ### Added
 
-* `shopify/jsx-prefer-fragment-wrappers`. [[#94](https://github.com/Shopify/eslint-plugin-shopify/pull/94)]
-* `shopify/jest/no-vague-titles`. [[#93](https://github.com/Shopify/eslint-plugin-shopify/pull/93)]
-* `shopify/strict-component-boundaries`. [[#98](https://github.com/Shopify/eslint-plugin-shopify/pull/98)]
+- `shopify/jsx-prefer-fragment-wrappers`. [[#94](https://github.com/Shopify/eslint-plugin-shopify/pull/94)]
+- `shopify/jest/no-vague-titles`. [[#93](https://github.com/Shopify/eslint-plugin-shopify/pull/93)]
+- `shopify/strict-component-boundaries`. [[#98](https://github.com/Shopify/eslint-plugin-shopify/pull/98)]
 
 ### Changed
 
-* **Breaking** Moved prettier to be a peerDependency, this avoids the potential for having multiple versions of prettier in the dependency graph. If you use prettier you will need to ensure you have it installed in your project as eslint-plugin-shopify will no longer install it for you. [[#107](https://github.com/Shopify/eslint-plugin-shopify/pull/107)]
-* **Breaking** Updated `typescript-eslint-parser` to support `typescript@2.9.1`. [[#102](https://github.com/Shopify/eslint-plugin-shopify/pull/102)]
+- **Breaking** Moved prettier to be a peerDependency, this avoids the potential for having multiple versions of prettier in the dependency graph. If you use prettier you will need to ensure you have it installed in your project as eslint-plugin-shopify will no longer install it for you. [[#107](https://github.com/Shopify/eslint-plugin-shopify/pull/107)]
+- **Breaking** Updated `typescript-eslint-parser` to support `typescript@2.9.1`. [[#102](https://github.com/Shopify/eslint-plugin-shopify/pull/102)]
 
 ## 22.1.0 - 2018-06-08
 
 ### Fixed
 
-* Updated `eslint-plugin-sort-class-members` dependency to version 1.3.1 in order to support node 10.
+- Updated `eslint-plugin-sort-class-members` dependency to version 1.3.1 in order to support node 10.
 
 ### Added
 
-* `shopify/prefer-pascal-case-enums`. [[#96](https://github.com/Shopify/eslint-plugin-shopify/pull/96)]
-* `shopify/react-prefer-private-members`. [[#95](https://github.com/Shopify/eslint-plugin-shopify/pull/95)]
+- `shopify/prefer-pascal-case-enums`. [[#96](https://github.com/Shopify/eslint-plugin-shopify/pull/96)]
+- `shopify/react-prefer-private-members`. [[#95](https://github.com/Shopify/eslint-plugin-shopify/pull/95)]
 
 ## 22.0.0
 
-* Updated dependencies
-* Added support for TypeScript 2.8
+- Updated dependencies
+- Added support for TypeScript 2.8
 
 ## 21.0.1 - 2018-04-25
 
-* Fixed the publish config for the package.
+- Fixed the publish config for the package.
 
 ## 21.0.0 - 2018-04-25
 
 ### Added
 
-* `shopify/jsx-no-hardcoded-content` now accepts a `dom` option that allows specifying attributes on DOM elements and Web Components to be checked for hardcoded content.
+- `shopify/jsx-no-hardcoded-content` now accepts a `dom` option that allows specifying attributes on DOM elements and Web Components to be checked for hardcoded content.
 
 ### Removed
 
-* **Breaking:** turned off four rules that previously triggered errors in all cases:
-  * `shopify/react-type-state` (TypeScript now addresses the issue this rule was meant to catch)
-  * `promise/always-return`
-  * `react/no-did-mount-set-state`
-  * `no-undefined`
-* **Breaking:** turned off two rules in specific plugins:
-  * `babel/no-invalid-this` (turned off for the `typescript` configs as TypeScript has better mechanisms for unsuring a valid `this` is used)
-  * `no-process-env` (turned off for the `webpack` and `node` configs as both targets can benefit from use of `process.env`)
+- **Breaking:** turned off four rules that previously triggered errors in all cases:
+  - `shopify/react-type-state` (TypeScript now addresses the issue this rule was meant to catch)
+  - `promise/always-return`
+  - `react/no-did-mount-set-state`
+  - `no-undefined`
+- **Breaking:** turned off two rules in specific plugins:
+  - `babel/no-invalid-this` (turned off for the `typescript` configs as TypeScript has better mechanisms for unsuring a valid `this` is used)
+  - `no-process-env` (turned off for the `webpack` and `node` configs as both targets can benefit from use of `process.env`)
 
 ### Fixed
 
-* Fixed an issue where various rules were not correctly resolving paths in `node_modules`.
+- Fixed an issue where various rules were not correctly resolving paths in `node_modules`.
 
 ## 20.0.0 - 2018-03-15
 
-* **Breaking:** the version of TypeScript supported by this plugin is 2.7.x (in line with [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser)’s TypeScript support)
-* Updated dependencies that support the new ESLint documentation URL metadata. Errors from these plugins are accompanied by a link to the documentation for the broken rule.
-* Dependencies are now strictly versioned for tighter control over the exact rules the plugin enforces.
+- **Breaking:** the version of TypeScript supported by this plugin is 2.7.x (in line with [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser)’s TypeScript support)
+- Updated dependencies that support the new ESLint documentation URL metadata. Errors from these plugins are accompanied by a link to the documentation for the broken rule.
+- Dependencies are now strictly versioned for tighter control over the exact rules the plugin enforces.
 
 | Package                    | old       | new       |
 | -------------------------- | --------- | --------- |
@@ -818,7 +813,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 | `eslint-plugin-react`      | `^7.5.1`  | `7.7.0`   |
 | `eslint-plugin-typescript` | `^0.8.1`  | `0.10.0`  |
 
-* Added rules:
+- Added rules:
   - [`react/forbid-dom-props`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-dom-props.md) (disabled)
   - [`react/jsx-child-element-spacing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-child-element-spacing.md) **error**
   - [`react/jsx-max-depth`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-max-depth.md) (disabled)
@@ -839,20 +834,20 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
   - [`promise/no-new-statics`](https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/no-new-statics.md) (disabled)
   - [`typescript/explicit-function-return-type`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/explicit-function-return-type.md) (disabled)
   - [`typescript/no-non-null-assertion`](https://github.com/nzakas/eslint-plugin-typescript/blob/master/docs/rules/no-non-null-assertion.md) **error**
-* Updated `import/extensions` due to changes in its implementation: some extensions are explicitly allowed in `import`s: `.svg`, `.png`, `.jpg`, `.ico`, `.css`, `.sass`, `.scss`, `.less`, `.styl`. `.json` is still required as well.
-* Chore: updated CircleCI from v1 to v2.
+- Updated `import/extensions` due to changes in its implementation: some extensions are explicitly allowed in `import`s: `.svg`, `.png`, `.jpg`, `.ico`, `.css`, `.sass`, `.scss`, `.less`, `.styl`. `.json` is still required as well.
+- Chore: updated CircleCI from v1 to v2.
 
 ## 19.0.1 - 2018-03-12
 
 ### Fixed
 
-* `shopify/jsx-no-hardcoded-content` rule now does not warn on all-whitespace strings as children. This was causing issues with indented JSX content, and is typically not an issue for different locales.
+- `shopify/jsx-no-hardcoded-content` rule now does not warn on all-whitespace strings as children. This was causing issues with indented JSX content, and is typically not an issue for different locales.
 
 ## 19.0.0 - 2018-01-17
 
 ### Added
 
-* `shopify/jest` config with [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) rules:
+- `shopify/jest` config with [eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) rules:
   - `jest/no-disabled-tests` (disabled)
   - `jest/no-focused-tests`
   - `jest/no-identical-title`
@@ -861,29 +856,29 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
   - `jest/prefer-to-be-null`
   - `jest/prefer-to-be-undefined`
   - `jest/valid-expect`
-* Added `shopify/webpack` config
-* Added `shopify/polaris` config
-* Added `shopify/webpack/no-unnamed-dynamic-imports` rule
-* Added `shopify/prefer-module-scope-constants` rule
-* Added `shopify/jsx-no-complex-expressions` rule
-* Added `shopify/jsx-no-hardcoded-content` rule
-* Added `shopify/polaris-no-bare-stack-item` rule
-* Added `shopify/polaris-prefer-sectioned-prop` rule
-* Added `shopify/react-initialize-state` rule
-* Added `shopify/react-type-state` rule
-* Added [`implicit-arrow-linebreak`][] rule
-* Added [`lines-around-comment`][] rule (as a [special
+- Added `shopify/webpack` config
+- Added `shopify/polaris` config
+- Added `shopify/webpack/no-unnamed-dynamic-imports` rule
+- Added `shopify/prefer-module-scope-constants` rule
+- Added `shopify/jsx-no-complex-expressions` rule
+- Added `shopify/jsx-no-hardcoded-content` rule
+- Added `shopify/polaris-no-bare-stack-item` rule
+- Added `shopify/polaris-prefer-sectioned-prop` rule
+- Added `shopify/react-initialize-state` rule
+- Added `shopify/react-type-state` rule
+- Added [`implicit-arrow-linebreak`][] rule
+- Added [`lines-around-comment`][] rule (as a [special
   rule][lines-around-comment-special]).
-* Added [`no-unexpected-multiline`][] rule (as a [special rule][no-unexpected-multiline-special]).
-* Added [`flowtype/no-flow-fix-me-comments`](https://github.com/gajus/eslint-plugin-flowtype/blob/677e55c6a0f1dd355268a0f19618cd2696424c53/.README/rules/no-flow-fix-me-comments.md)
-* Added [`react/jsx-one-expression-per-line`][]
-* Added [`react/destructuring-assignment`][]
-* Added [`react/no-access-state-in-setstate`][]
-* Added [`react/button-has-type`][]
-* Added [`react/jsx-curly-brace-presence`][]
-* Added [`typescript/member-naming`](https://github.com/nzakas/eslint-plugin-typescript/tree/master/docs/rules/member-naming.md)
-* Added [`typescript/no-array-constructor`](https://github.com/nzakas/eslint-plugin-typescript/tree/master/docs/rules/no-array-constructor.md)
-* Added `yarn prettier` script (prettifies source files)
+- Added [`no-unexpected-multiline`][] rule (as a [special rule][no-unexpected-multiline-special]).
+- Added [`flowtype/no-flow-fix-me-comments`](https://github.com/gajus/eslint-plugin-flowtype/blob/677e55c6a0f1dd355268a0f19618cd2696424c53/.README/rules/no-flow-fix-me-comments.md)
+- Added [`react/jsx-one-expression-per-line`][]
+- Added [`react/destructuring-assignment`][]
+- Added [`react/no-access-state-in-setstate`][]
+- Added [`react/button-has-type`][]
+- Added [`react/jsx-curly-brace-presence`][]
+- Added [`typescript/member-naming`](https://github.com/nzakas/eslint-plugin-typescript/tree/master/docs/rules/member-naming.md)
+- Added [`typescript/no-array-constructor`](https://github.com/nzakas/eslint-plugin-typescript/tree/master/docs/rules/no-array-constructor.md)
+- Added `yarn prettier` script (prettifies source files)
 
 [`implicit-arrow-linebreak`]: https://eslint.org/docs/rules/implicit-arrow-linebreak
 [lines-around-comment-special]: https://github.com/prettier/eslint-config-prettier/blob/5399175c37466747aae9d407021dffec2c169c8b/README.md#lines-around-comment
@@ -898,63 +893,65 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 ### Changed
 
-* Updated dependencies to their latest versions (full details in [#63](https://github.com/Shopify/eslint-plugin-shopify/pull/63))
-* **Breaking:** `node.js` minimum supported node version update to `8.9.4` (LTS).
-* **Breaking:** Changed `eslint-config-shopify` codebase to `trailingComma: 'all'` and drop support for Node.js 6
-* **Breaking:** Updated prettier to 1.9.2, introducing a change in function parens style (set to `arrowParens: 'always'`):
+- Updated dependencies to their latest versions (full details in [#63](https://github.com/Shopify/eslint-plugin-shopify/pull/63))
+- **Breaking:** `node.js` minimum supported node version update to `8.9.4` (LTS).
+- **Breaking:** Changed `eslint-config-shopify` codebase to `trailingComma: 'all'` and drop support for Node.js 6
+- **Breaking:** Updated prettier to 1.9.2, introducing a change in function parens style (set to `arrowParens: 'always'`):
 
-    ```js
-    // Before
-    const foo = myArray.map(foo => {});
+  ```js
+  // Before
+  const foo = myArray.map((foo) => {});
 
-    // After
-    const foo = myArray.map((foo) => {});
-    ```
+  // After
+  const foo = myArray.map((foo) => {});
+  ```
 
-    ⚠️ Upgrade path:
+  ⚠️ Upgrade path:
 
-    Your project config files (`package.json`, `.prettierrc`, `.eslintrc`…)
-    may need to be updated like so:
+  Your project config files (`package.json`, `.prettierrc`, `.eslintrc`…)
+  may need to be updated like so:
 
-    ```diff
-       "singleQuote": true,
-       "bracketSpacing": false,
-       "trailingComma": "all",
-    +  "arrowParens": "always"
-    ```
-* Prettified source files using the new config
+  ```diff
+     "singleQuote": true,
+     "bracketSpacing": false,
+     "trailingComma": "all",
+  +  "arrowParens": "always"
+  ```
+
+- Prettified source files using the new config
 
 ## 18.3.1 - 2017-12-21
 
 ### Changed
 
-* Changed `eslint-config-shopify` codebase to follow es5 trailingComma. [[#61](https://github.com/Shopify/eslint-plugin-shopify/pull/61)]
+- Changed `eslint-config-shopify` codebase to follow es5 trailingComma. [[#61](https://github.com/Shopify/eslint-plugin-shopify/pull/61)]
 
 ## 18.3.0 - 2017-12-18
 
 ### Added
 
-* Added `shopify/no-debugger`, which behaves the same as ESLint's `no-debugger` but without a fixer.
+- Added `shopify/no-debugger`, which behaves the same as ESLint's `no-debugger` but without a fixer.
 
 ## 18.2.0 - 2017-12-04
 
 ### Added
 
-* Added a `typescript-prettier` config to run prettier against typescript projects.
+- Added a `typescript-prettier` config to run prettier against typescript projects.
 
 ## 18.1.0 - 2017-12-01
 
 ### Added
 
-* Added a `typescript` and `typescript-react` config. [[#54](https://github.com/Shopify/eslint-plugin-shopify/pull/54)]
+- Added a `typescript` and `typescript-react` config. [[#54](https://github.com/Shopify/eslint-plugin-shopify/pull/54)]
 
 ### Changed
 
-* `plugin:shopify/prettier` will now enforce trailing commas in function parameter calls. [[#55](https://github.com/Shopify/eslint-plugin-shopify/pull/55)]
-* `comma-dangle` will now enforce multi-line function parameters. [[#55](https://github.com/Shopify/eslint-plugin-shopify/pull/55)]
-* Removed `plugin:shopify/esnext` as an included extension of the `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended by the consumer to use the `plugin:shopify/prettier`. [[#53](https://github.com/Shopify/eslint-plugin-shopify/pull/53)]
+- `plugin:shopify/prettier` will now enforce trailing commas in function parameter calls. [[#55](https://github.com/Shopify/eslint-plugin-shopify/pull/55)]
+- `comma-dangle` will now enforce multi-line function parameters. [[#55](https://github.com/Shopify/eslint-plugin-shopify/pull/55)]
+- Removed `plugin:shopify/esnext` as an included extension of the `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended by the consumer to use the `plugin:shopify/prettier`. [[#53](https://github.com/Shopify/eslint-plugin-shopify/pull/53)]
 
   Example (`package.json`):
+
   ```
   "eslintConfig": {
     "extends": [
@@ -968,21 +965,22 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 
 ### Changed
 
-* Turned off `class-methods-use-this`
+- Turned off `class-methods-use-this`
 
 ## 17.2.1 - 2017-10-30
 
 ### Changed
 
-* Turned off `babel/semi` rule in prettier config
+- Turned off `babel/semi` rule in prettier config
 
 ## 17.2.0 - 2017-10-25
 
 ### Added
 
-* Added a prettier config. [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]
+- Added a prettier config. [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]
 
 Example:
+
 ```
 "eslintConfig": {
   "extends": [
@@ -993,20 +991,19 @@ Example:
 
 ### Changed
 
-* Replace all `warn` with `error`. [[#48](https://github.com/Shopify/eslint-plugin-shopify/pull/48)]
-* `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`). [[#43](https://github.com/Shopify/eslint-plugin-shopify/pull/43)]
-* Enable `padding-line-between-statements` for directives. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
+- Replace all `warn` with `error`. [[#48](https://github.com/Shopify/eslint-plugin-shopify/pull/48)]
+- `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`). [[#43](https://github.com/Shopify/eslint-plugin-shopify/pull/43)]
+- Enable `padding-line-between-statements` for directives. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 ### Removed
 
-* `lines-around-directive` was deprecated in ESLint `v4.0.0`. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
-
+- `lines-around-directive` was deprecated in ESLint `v4.0.0`. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 ## 17.1.0 - 2017-09-19
 
 ### Added
 
-* New rules. [[#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)]:
+- New rules. [[#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)]:
   - `import/no-anonymous-default-export`
   - `jsx-a11y/anchor-is-valid`
   - `no-buffer-constructor`
@@ -1026,7 +1023,6 @@ Example:
   - `padding-line-between-statements` (disabled)
   - `semi-style`
   - `switch-colon-spacing`
-
 
 ### Changed
 
@@ -1056,7 +1052,6 @@ Example:
   - `eslint-plugin-mocha`: `^4.9.0` → `^4.11.0`.
   - `eslint-plugin-node`: `^4.2.2` → `^4.2.3`.
   - `eslint-plugin-react`: `^7.0.0` → `^7.0.1`.
-
 
 ## 16.0.1 - 2017-05-29
 
@@ -1105,7 +1100,6 @@ Example:
 - Deprecated: [`jsx-a11y/onclick-has-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
 - Deprecated: [`jsx-a11y/onclick-has-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
 - Deprecated: [`jsx-a11y/jsx-space-before-closing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06)
-
 
 ## 15.2.0 - 2017-03-06
 

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -23,11 +23,13 @@ $ npm i eslint --save-dev
 Next, install `@shopify/eslint-plugin`:
 
 **With Yarn**
+
 ```bash
 yarn add --dev @shopify/eslint-plugin
 ```
 
 **With npm**
+
 ```bash
 $ npm install @shopify/eslint-plugin --save-dev
 ```
@@ -56,10 +58,7 @@ You can also add some "augmenting" configs on top of the "core" config by extend
 
 ```json
 {
-  "extends": [
-    "plugin:@shopify/esnext",
-    "plugin:@shopify/react"
-  ]
+  "extends": ["plugin:@shopify/esnext", "plugin:@shopify/react"]
 }
 ```
 
@@ -70,7 +69,7 @@ Likewise, if you are using TypeScript and React, the following configuration ext
   "extends": [
     "plugin:@shopify/typescript",
     "plugin:@shopify/react",
-    "plugin:@shopify/prettier",
+    "plugin:@shopify/prettier"
   ]
 }
 ```
@@ -98,6 +97,7 @@ This plugin also provides the following tool-specific configurations, which can 
   }
 }
 ```
+
 - [react](lib/config/react.js): Use this for React projects.
 - [graphql](lib/config/graphql.js): Use this for projects that use [graphql-config](https://github.com/prisma/graphql-config) for graphql validation.
 - [polaris](lib/config/polaris.js): Use this for projects that use [Shopify’s React Polaris components](https://polaris.shopify.com/components/get-started).
@@ -112,10 +112,7 @@ A node project that will use Babel for transpilation would need the following ES
 
 ```json
 {
-  "extends": [
-    "plugin:@shopify/esnext",
-    "plugin:@shopify/node"
-  ]
+  "extends": ["plugin:@shopify/esnext", "plugin:@shopify/node"]
 }
 ```
 

--- a/packages/images/README.md
+++ b/packages/images/README.md
@@ -16,4 +16,4 @@ $ yarn add @shopify/images
 
 This package exports helpers for optimizing images. The following members are exported:
 
-* `svgOptions`: an object containing our recommended options for using SVGO.
+- `svgOptions`: an object containing our recommended options for using SVGO.

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Explicitly set default for `"arrowParens": "always"`.  Although it is a default for prettier as of v2.0, it was `avoid` in prior versions.  Specifying it explicitly here will result in the same config, not matter which version of prettier used.
+- Explicitly set default for `"arrowParens": "always"`. Although it is a default for prettier as of v2.0, it was `avoid` in prior versions. Specifying it explicitly here will result in the same config, not matter which version of prettier used.
 
 ## 1.0.0 - 2020-05-12
 

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -1,6 +1,6 @@
 # `@shopify/prettier-config`
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)  [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](../../LICENSE.md) [![npm version](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg)](https://badge.fury.io/js/%40shopify%2Fprettier-config.svg) [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/prettier-config.svg)
 
 Shared prettier configuration
 
@@ -11,10 +11,13 @@ $ yarn add --dev @shopify/prettier-config
 ```
 
 ## Usage
+
 Shopify’s shared prettier config comes bundled in `@shopify/prettier-config`. To enable these rules, add a `prettier` property in your `package.json` and reference this shared config as follows:
+
 ```
 "prettier": "@shopify/prettier-config"
 ```
-Previously, rules had been defined directly in a `.prettierrc` or `package.json` 
+
+Previously, rules had been defined directly in a `.prettierrc` or `package.json`
 
 Any previous `.prettierrc` should be removed in favour of the shared config.

--- a/packages/stylelint-plugin/CHANGELOG.md
+++ b/packages/stylelint-plugin/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 ### Breaking Change
 
-- Projects will need to use stylelint v13.7.0 or higher 
+- Projects will need to use stylelint v13.7.0 or higher
 - Stylelint rules have been renamed. `*-blacklist`, `*-requirelist` and `*-whitelist` rules have been replaced in favour of the new `*-disallowed-list`, `*-required-list` and `*-allowed-list` ones.
 
 ## 9.0.0 - 2020-06-04
@@ -67,7 +67,7 @@
 
 The Shopify stylelint rules have been renamed to follow the `@shopify` namespace convention
 
-Before: 
+Before:
 
 ```
 module.exports = {
@@ -78,7 +78,7 @@ module.exports = {
 };
 ```
 
-After: 
+After:
 
 ```
 module.exports = {
@@ -194,7 +194,6 @@ After:
   - [scss/no-dollar-variables](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/no-dollar-variables/README.md) (disabled)
   - [scss/no-duplicate-dollar-variables](https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/no-duplicate-dollar-variables/README.md)
 
-
 ## 6.1.0 - 2018-08-07
 
 - Update dependency: use stylelint-config-prettier v4.0.0. This is identical to v3.3.0 except it moves stylelint to be a peerDependency, which means there is less chance for installing multiple versions of stylelint.
@@ -213,7 +212,7 @@ Migration Suggestions:
 
 ## 5.1.2 - 2018-07-10
 
-- Changed dependency: Pull the base prettier config from stylelint-config-prettier instead of  prettier-stylelint-formatter. It is provided by the prettier organisation and is more up to date than the one provided by prettier-stylelint-formatter
+- Changed dependency: Pull the base prettier config from stylelint-config-prettier instead of prettier-stylelint-formatter. It is provided by the prettier organisation and is more up to date than the one provided by prettier-stylelint-formatter
 - Increase stylelint minimum version to 9.1.1 so it aligns with the minumum required by stylelint-config-prettier
 
 ## 5.1.1 - 2018-07-10
@@ -223,21 +222,29 @@ Migration Suggestions:
 The following patterns are considered violations:
 
 ```css
-.foo::before { content: 'bar'; }
+.foo::before {
+  content: 'bar';
+}
 ```
 
 ```css
-.foo::before { content: open-quote 'Section' counter(section_counter) close-quote; }
+.foo::before {
+  content: open-quote 'Section' counter(section_counter) close-quote;
+}
 ```
 
 The following patterns are _not_ considered violations:
 
 ```css
-.foo::before { content: ''; }
+.foo::before {
+  content: '';
+}
 ```
 
 ```css
-.foo::before { content: open-quote counter(section_counter) close-quote; }
+.foo::before {
+  content: open-quote counter(section_counter) close-quote;
+}
 ```
 
 ## 5.1.0 - 2018-07-05
@@ -263,13 +270,13 @@ Migration Suggestions:
 
 - If `stylelint-config-shopify/prettier` is used, please replace `prettier-stylelint` with `prettier-stylelint-formatter`.
 
-    ```
-    yarn remove prettier-stylelint && yarn add prettier-stylelint-formatter
-    ```
+  ```
+  yarn remove prettier-stylelint && yarn add prettier-stylelint-formatter
+  ```
 
 ## 3.0.2 - 2017-11-14
 
-* `declaration-block-no-redundant-longhand-properties` now allows longhand `grid` properties, see [#21](https://github.com/Shopify/stylelint-config-shopify/pull/21)
+- `declaration-block-no-redundant-longhand-properties` now allows longhand `grid` properties, see [#21](https://github.com/Shopify/stylelint-config-shopify/pull/21)
 
 ## 3.0.1 - 2017-11-13
 
@@ -325,64 +332,62 @@ The following patterns are considered warnings:
 
 ## 2.1.0 - 2017-08-25
 
-
 ### Changed
 
-* `media-feature-name-no-unknown` to ignore `prefers-reduced-motion`
-* [stylelint-scss](https://github.com/kristerkari/stylelint-scss) from `1.4.x` to `^2.0.1`
-* Replaced deprecated `scss/at-mixin-no-argumentless-call-parentheses` rule with its equivalent `scss/at-mixin-argumentless-call-parentheses`
-* Updated `eslint-plugin-shopify` to the latest version, and updated ESLint to the appropriate version
+- `media-feature-name-no-unknown` to ignore `prefers-reduced-motion`
+- [stylelint-scss](https://github.com/kristerkari/stylelint-scss) from `1.4.x` to `^2.0.1`
+- Replaced deprecated `scss/at-mixin-no-argumentless-call-parentheses` rule with its equivalent `scss/at-mixin-argumentless-call-parentheses`
+- Updated `eslint-plugin-shopify` to the latest version, and updated ESLint to the appropriate version
 
 ## 2.0.1 - 2017-07-28
 
 ### Changed
 
-* Set `selector-max-type` to 1
+- Set `selector-max-type` to 1
 
 ## 2.0.0 - 2017-07-27
 
 ### Added
 
-* New plugin:
-  * Added `stylelint-order` which replaces `declaration-block-properties-order`
-
-* New rules:
-  * `rule-empty-line-before`
-  * `selector-max-universal`
-  * `at-rule-semicolon-space-before`
-  * `selector-max-attribute`
-  * `selector-max-class`
-  * `selector-max-combinators`
-  * `selector-max-id`
-  * `selector-max-type`
-  * `function-url-scheme-blacklist` (disabled)
-  * `media-feature-name-whitelist` (disabled)
-  * `time-min-milliseconds` (disabled)
+- New plugin:
+  - Added `stylelint-order` which replaces `declaration-block-properties-order`
+- New rules:
+  - `rule-empty-line-before`
+  - `selector-max-universal`
+  - `at-rule-semicolon-space-before`
+  - `selector-max-attribute`
+  - `selector-max-class`
+  - `selector-max-combinators`
+  - `selector-max-id`
+  - `selector-max-type`
+  - `function-url-scheme-blacklist` (disabled)
+  - `media-feature-name-whitelist` (disabled)
+  - `time-min-milliseconds` (disabled)
 
 ### Removed
 
-* Deprecated rules:
-  * `block-no-single-line`
-  * `no-indistinguishable-colors`
-  * `declaration-block-no-ignored-properties`
-  * `declaration-block-properties-order`
-  * `function-url-data-uris`
-  * `no-browser-hacks`
-  * `no-unsupported-browser-features`
-  * `media-feature-no-missing-punctuation`
-  * `custom-property-no-outside-root`
-  * `root-no-standard-properties`
-  * `rule-nested-empty-line-before`
-  * `rule-non-nested-empty-line-before`
-
+- Deprecated rules:
+  - `block-no-single-line`
+  - `no-indistinguishable-colors`
+  - `declaration-block-no-ignored-properties`
+  - `declaration-block-properties-order`
+  - `function-url-data-uris`
+  - `no-browser-hacks`
+  - `no-unsupported-browser-features`
+  - `media-feature-no-missing-punctuation`
+  - `custom-property-no-outside-root`
+  - `root-no-standard-properties`
+  - `rule-nested-empty-line-before`
+  - `rule-non-nested-empty-line-before`
 
 ### Changed
 
-* Properties order for shorthand notation with margin, padding, border styles have been updated to follow:
+- Properties order for shorthand notation with margin, padding, border styles have been updated to follow:
+
 ```
 property: <top> <right> <bottom> <left>
 ```
 
 ## 1.0.0 - 2017-05-29
 
-* Initial release
+- Initial release

--- a/packages/stylelint-plugin/README.md
+++ b/packages/stylelint-plugin/README.md
@@ -9,19 +9,21 @@ Shopify's stylelint rules and config
 Install [stylelint](https://stylelint.io/) and `@shopify/stylelint-plugin`:
 
 **With Yarn**
+
 ```
 yarn add --dev stylelint @shopify/stylelint-plugin
 ```
 
 **With npm**
+
 ```
 npm install stylelint @shopify/stylelint-plugin --save-dev
 ```
 
-
 ## Usage
 
 Shopify’s stylelint rules come bundled in `@shopify/stylelint-plugin`. To enable these rules, add a `stylelint` property in your `package.json`. See the [stylelint configuration docs](https://stylelint.io/user-guide/configuration/) for more details.
+
 ```
 "stylelint": {
   "extends": ["@shopify/stylelint-plugin"]
@@ -29,19 +31,23 @@ Shopify’s stylelint rules come bundled in `@shopify/stylelint-plugin`. To enab
 ```
 
 Now you can run stylelint by adding the following linting script to your `package.json`. See the [stylelint CLI docs](https://stylelint.io/user-guide/cli/) for more details.
+
 ```
 "scripts": {
   "stylelint": "stylelint 'src/**/*.scss'"
 }
 ```
+
 Run it:
 
 **With Yarn**
+
 ```
 yarn run stylelint
 ```
 
 **With npm**
+
 ```
 npm run stylelint
 ```

--- a/packages/typescript-configs/CHANGELOG.md
+++ b/packages/typescript-configs/CHANGELOG.md
@@ -24,13 +24,13 @@ Set `isolatedModules` to be true by default. Sewing-kit is moving away from a `t
 
 The Shopify typescript definition for `.scss` and `.css` have changed.
 
-Before: 
+Before:
 
 ```
 import * as styles from 'foo.scss';
 ```
 
-After: 
+After:
 
 ```
 import styles from 'foo.scss';
@@ -42,4 +42,3 @@ import styles from 'foo.scss';
 
 - Start of Changelog
 - Move the package from [`sewing-kit`](https://github.com/Shopify/sewing-kit).
-

--- a/packages/typescript-configs/dom.json
+++ b/packages/typescript-configs/dom.json
@@ -2,12 +2,7 @@
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "scripthost",
-      "es2020"
-    ],
+    "lib": ["dom", "dom.iterable", "scripthost", "es2020"],
     "module": "esnext",
     "target": "es2020"
   },

--- a/templates/ROOT_README.hbs.md
+++ b/templates/ROOT_README.hbs.md
@@ -1,4 +1,4 @@
-[comment]: # (NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead)
+[comment]: # 'NOTE: This file is generated and should not be modify directly. Update `templates/ROOT_README.hbs.md` instead'
 
 # Web Configs
 
@@ -13,14 +13,16 @@ This repo is managed as a monorepo that is composed of many npm packages, where 
 ### Package Index
 
 | Name | NPM | Size |
-| ------- | --- | --- |
+| ---- | --- | ---- |
+
+
 {{#each jsPackageNames}}
 | [{{this}}](packages/{{this}}) | [![npm version](https://badge.fury.io/js/%40shopify%2F{{this}}.svg)](https://badge.fury.io/js/%40shopify%2F{{this}}) | [![npm bundle size (minified + gzip)](https://img.shields.io/bundlephobia/minzip/@shopify/{{this}}.svg)](https://img.shields.io/bundlephobia/minzip/@shopify/{{this}}.svg) |
 {{/each}}
 
 ## Contribution
 
-This repository has a CLA-Bot running which will ask contributors to sign a Contributor License Agreement (CLA). 
+This repository has a CLA-Bot running which will ask contributors to sign a Contributor License Agreement (CLA).
 
 Shopify has also adopted a Code of Conduct that we expect contributors to adhere to. Please read the [full text](./CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
 
@@ -60,11 +62,11 @@ More usage instructions on the `tophat` command can be [found here](https://gith
 
 #### Documentation
 
-If your change affects the public API of any packages within this repository (i.e. adding or changing arguments to a function, adding a new function, changing the return value, etc), please ensure the documentation is updated,  and a changelog is added to reflect this. Documentation is in the `README.md` files of each package. If further documentation is needed please communicate via a GitHub issue.
+If your change affects the public API of any packages within this repository (i.e. adding or changing arguments to a function, adding a new function, changing the return value, etc), please ensure the documentation is updated, and a changelog is added to reflect this. Documentation is in the `README.md` files of each package. If further documentation is needed please communicate via a GitHub issue.
 
 #### Testing
 
-The packages in this repository are used in mission-critical production scenarios. As such, we do not merge any untested code. 
+The packages in this repository are used in mission-critical production scenarios. As such, we do not merge any untested code.
 
 To run the full test suite, simply run `dev test` or `yarn test`.
 


### PR DESCRIPTION
## Description

I saw that the changeset PR was very noisy as the CHANGELOG files aren't currently formatted with prettier. We should format them to make sure that the changeset PRs are quiet.


This PR:

- Saves the result of running prettier against md, json and yml files
- Ignores packages/eslint-plugin/docs/rules/**/*.md directory as they often contain "this is a violation" code examples that syntax that prettier wants to format (we could go back to this later if we care by adding `<!-prettier-ignore -->` comments in front of those codeblocks)
- Adds running prettier over md/json/yml files to the CI lint step to avoid regressions.


I'm going to skip the changesets for this PR as the changes don't have any impact. They can go out as part of whatever release happens next.