### PR TITLE
Update eslint-plugin-prettier and remove override for graphql files

### DIFF
--- a/.changeset/chilly-cycles-breathe.md
+++ b/.changeset/chilly-cycles-breathe.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': patch
+---
+
+Update `eslint-plugin-prettier` to `v4.1.0`, to automatically skip trying to run prettier over graphql files. Remove the explicit override for disabling prettier in graphql files, as it will cause eslint's "work out what extensions need linting" logic to try to parse graphql files. Add `{overrides: {files: ['*.graphql', '*.gql'], rules: {'prettier/prettier': 'off'}}}` to your eslint config if want to disable running the prettier rule over graphql files entirely.

--- a/packages/eslint-plugin/lib/config/prettier.js
+++ b/packages/eslint-plugin/lib/config/prettier.js
@@ -21,16 +21,6 @@ module.exports = {
 
   overrides: [
     {
-      // disable prettier processing of graphql files
-      // eslint-plugin-graphql is required to process graphql files, but it also
-      // suppresses all lint violations except its own, which results in a
-      // wasteful no-op.
-      files: ['*.graphql', '*.gql'],
-      rules: {
-        'prettier/prettier': 'off',
-      },
-    },
-    {
       files: ['*.ts', '*.tsx'],
       rules: {
         '@typescript-eslint/quotes': 'off',

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-jest-formatting": "^3.1.0",
     "eslint-plugin-jsx-a11y": "^6.5.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^4.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.30.0",
     "eslint-plugin-react-hooks": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,10 +3241,10 @@ eslint-plugin-node@^11.1.0:
     resolve "^1.10.1"
     semver "^6.1.0"
 
-eslint-plugin-prettier@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
-  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+eslint-plugin-prettier@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.1.0.tgz#1cd4b3fadf3b3cdb30b1874b55e7f93f85eb43ad"
+  integrity sha512-A3AXIEfTnq3D5qDFjWJdQ9c4BLhw/TqhSR+6+SVaoPJBAWciFEuJiNQh275OnjRrAi7yssZzuWBRw66VG2g6UA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION
## Description

As of v4.1.0 eslint-plugin-prettier shall inherently skip running over
graphql files, so the override to turn that off is not needed.

This means we can remove the override to disable prettier for graphql
files, as this had the undesired effect of making eslint's "work out
what files to lint based on the file extensions used in overrides" logic
think that eslint should try to lint graphql files if you used the
`plugin:@shopify/prettier` preset