### PR TITLE
Add eslint rule ensuring Polaris <Modal /> is provided an 'activator' prop

### DIFF
--- a/packages/eslint-plugin/docs/rules/polaris-modal-requires-activator-prop.md
+++ b/packages/eslint-plugin/docs/rules/polaris-modal-requires-activator-prop.md
@@ -1,1 +1,1 @@
-// stubbed for now until first-pass code review
+// stubbed for now until go-ahead is given

--- a/packages/eslint-plugin/docs/rules/polaris-modal-requires-activator-prop.md
+++ b/packages/eslint-plugin/docs/rules/polaris-modal-requires-activator-prop.md
@@ -1,0 +1,1 @@
+// stubbed for now until first-pass code review

--- a/packages/eslint-plugin/lib/rules/polaris-modal-requires-activator-prop.js
+++ b/packages/eslint-plugin/lib/rules/polaris-modal-requires-activator-prop.js
@@ -1,0 +1,34 @@
+const {docsUrl, polarisComponentFromJSX} = require('../utilities');
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Polaris <Modal /> and components that extend it must provide an `activator` prop to ensure proper keyboard focus handling on close',
+      category: 'Best Practices',
+      recommended: true,
+      uri: docsUrl('polaris-modal-requires-activator-prop'),
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        const component = polarisComponentFromJSX(node, context);
+        if (
+          component === 'Modal' &&
+          node.openingElement.attributes.filter(
+            (attribute) => attribute.name.name === 'activator',
+          ).length === 0
+        ) {
+          context.report({
+            node,
+            message:
+              "Polaris <Modal /> should have an 'activator' prop to ensure correct keyboard focus handling on close.",
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/tests/lib/rules/polaris-modal-requires-activator-prop.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/polaris-modal-requires-activator-prop.test.js
@@ -1,0 +1,43 @@
+const {RuleTester} = require('eslint');
+
+const {fixtureFile} = require('../../utilities');
+const rule = require('../../../lib/rules/polaris-modal-requires-activator-prop');
+
+const ruleTester = new RuleTester();
+const parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module',
+  ecmaFeatures: {jsx: true},
+};
+
+const errors = [
+  {
+    type: 'JSXElement',
+    message:
+      "Polaris <Modal /> should have an 'activator' prop to ensure correct keyboard focus handling on close.",
+  },
+];
+
+ruleTester.run('polaris-modal-requires-activator-prop', rule, {
+  valid: [
+    {
+      code: `
+        import {Modal} from '@shopify/polaris';
+        <Modal activator={true} />;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        import {Modal} from '@shopify/polaris';
+        <Modal />;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+      errors,
+    },
+  ],
+});


### PR DESCRIPTION
## Description

This adds an eslint rule to check that Polaris `<Modal />` components are written with an `activator` prop. When used correctly, the `activator` prop ensures that when the modal is closed, keyboard focus is returned to the button that opened the modal. This is a very common a11y issue in Shopify's admin.

## Background

This PR is an attempt to get a 'small win' based on the issue and draft proposal by @qt314 at https://github.com/Shopify/web/issues/61982. 

## 🎩 instructions

I want to check with senior devs if this is a sensible rule that will have positive results. I'd like to hear any questions or concerns you have before taking this PR further.

## Next steps

- [x] alignment and strategy check
- [ ] move this PR over to `web`, at `web/tree/main/tooling/eslint`
- [x] per @BPScott's comment, run this on `web` and collect data about current violations, especially ones that are not currently possible to resolve (like the `secondaryActions` [issue on index pages](https://github.com/Shopify/core-issues/issues/43730))

#### Cross-team outreach

- [ ] check in with Polaris team about context on why `activator` is optional
- [ ] check in with [#admin-web-developer-acceleration](https://shopify.slack.com/archives/C02GM7ZR1J6) (or the right team, if they're not) for guidance and opinions

#### Go / no-go

- [ ] check-in on scope and workplan with @tatianau and any other stakeholders

#### Delivery

- [ ] resolve or disable the rule for existing violations (consider maybe should be at least 80:20 for resolve vs disable)