### PR TITLE
Cache repeated directory lookups for 12% speedup

### DIFF
--- a/.changeset/violet-laws-provide.md
+++ b/.changeset/violet-laws-provide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': patch
+---
+
+Speedup polaris linting rules by about 12% via caching already resolved files.


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

While profiling eslint tasks in various projects, I noticed that the polaris-related linting rules we have, take up a more time than necessary. This is most noticeable when when the project contains lots of files.

<img width="447" alt="Screenshot 2023-01-09 at 19 03 01" src="https://user-images.githubusercontent.com/1062408/211376793-0613afd5-b68a-41fc-85f7-ddd0d794aafd.png">

The majority of the time in those two rules is spent in `normalizeSource` which traverses directories upwards to find the npm package root. This is perfectly fine if we haven't seen the file before, but unnecessarily expensive when we _did_ resolve it once already. In the projects I tried this PR on, 95% of calls to `normalizeSource` are with a source file that we resolved already.

Therefore adding a simple caching mechanism bypasses the directory traversal and leads to about 12% faster linting times on the project I've tested it on.