### PR TITLE
Don't replace top/right/bottom/left declarations with inset

### DIFF
--- a/.changeset/strong-wolves-impress.md
+++ b/.changeset/strong-wolves-impress.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-plugin': patch
+---
+
+Don't replace `top`/`right`/`bottom`/`left` declarations with `inset` shorthand as `inset` is only supported in iOS Safari 14.5+

--- a/packages/stylelint-plugin/index.js
+++ b/packages/stylelint-plugin/index.js
@@ -82,9 +82,7 @@ module.exports = {
     // Disallow longhand properties that can be combined into one shorthand property.
     'declaration-block-no-redundant-longhand-properties': [
       true,
-      {
-        ignoreShorthands: ['/^grid.*/'],
-      },
+      {ignoreShorthands: ['/^grid.*/', 'inset']},
     ],
     // Disallow shorthand properties that override related longhand properties within declaration blocks.
     'declaration-block-no-shorthand-property-overrides': true,


### PR DESCRIPTION

## Description

Disable the autofix added in Stylelint 15.3 that performs this replacement, as inset is only supported in iOS Safari 14.5+, which we can still potentially support

```diff
a {
-  top: 1;
-  right: 2;
-  bottom: 3;
-  left: 4;
+  inset: 1 2 3 4;
}
```