### PR TITLE
[eslint plugin] Add back support for `Card` and `Stack` to polaris rules

### DIFF
--- a/.changeset/brave-masks-march.md
+++ b/.changeset/brave-masks-march.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/eslint-plugin': patch
+'@shopify/eslint-plugin': minor
 ---
 
-Updated component URLs for polaris.shopify.com and updated `polaris-no-bare-stack-item` to use `LegacyStack` and `polaris-prefer-sectioned-prop` to use `LegacyCard`'
+Updated component URLs for polaris.shopify.com and updated `polaris-no-bare-stack-item` to support `LegacyStack` and `polaris-prefer-sectioned-prop` to support `LegacyCard`'

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -132,7 +132,7 @@ This plugin provides the following custom rules, which are included as appropria
 - [jsx-prefer-fragment-wrappers](docs/rules/jsx-prefer-fragment-wrappers.md): Disallow useless wrapping elements in favour of fragment shorthand in JSX.
 - [no-namespace-imports](docs/rules/no-namespace-imports.md): Prevent namespace import declarations.
 - [no-useless-computed-properties](docs/rules/no-useless-computed-properties.md): Prevent the usage of unnecessary computed properties.
-- [polaris-no-bare-stack-item](docs/rules/polaris-no-bare-stack-item.md): Disallow the use of Polaris’s `LegacyStack.Item` without any custom props.
+- [polaris-no-bare-stack-item](docs/rules/polaris-no-bare-stack-item.md): Disallow the use of Polaris’s `Stack.Item` and `LegacyStack.Item` without any custom props.
 - [polaris-prefer-sectioned-prop](docs/rules/polaris-prefer-sectioned-prop.md): Prefer the use of the `sectioned` props in Polaris components instead of wrapping all contents in a `Section` component.
 - [prefer-class-properties](docs/rules/prefer-class-properties.md): Prefer class properties to assignment of literals in constructors.
 - [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.

--- a/packages/eslint-plugin/docs/rules/polaris-no-bare-stack-item.md
+++ b/packages/eslint-plugin/docs/rules/polaris-no-bare-stack-item.md
@@ -1,6 +1,6 @@
-# Disallow the use of Polaris’s `LegacyStack.Item` without any custom props. (polaris-no-bare-stack-item)
+# Disallow the use of Polaris’s `Stack.Item` and `LegacyStack.Item` without any custom props. (polaris-no-bare-stack-item)
 
-The Polaris [`LegacyStack` component](https://polaris.shopify.com/components/layout-and-structure/legacy-stack) has an `Item` subcomponent that is automatically wrapped around all children. As such, it is useless to wrap any content in a `LegacyStack.Item` unless a non-default prop value is provided. This rule prevents creating such items.
+The Polaris [`Stack` component](https://polaris.shopify.com/components/deprecated/stack) and [`LegacyStack` component](https://polaris.shopify.com/components/layout-and-structure/legacy-stack) have an `Item` subcomponent that is automatically wrapped around all children. As such, it is useless to wrap any content in a `Stack.Item` or `LegacyStack.Item` unless a non-default prop value is provided. This rule prevents creating such items.
 
 Note that this rule will only work if the Stack component was explicitly imported using a named, default, or namespace import, and not when using dynamic imports (`import('@shopify/polaris')`).
 
@@ -10,9 +10,12 @@ The following patterns are considered warnings:
 
 ```js
 import * as Polaris from '@shopify/polaris';
-import {LegacyStack} from '@shopify/polaris';
-import {LegacyStack as PolarisLegacyStack} from '@shopify/polaris';
+import {Stack, LegacyStack} from '@shopify/polaris';
+import {Stack as PolarisStack, LegacyStack as PolarisLegacyStack} from '@shopify/polaris';
 
+<Stack><Stack.Item>Content</Stack.Item></Stack>
+<Polaris.Stack.Item>Content</Polaris.Stack.Item>
+<PolarisStack.Item>Content</PolarisStack.Item>
 <LegacyStack><LegacyStack.Item>Content</LegacyStack.Item></LegacyStack>
 <Polaris.LegacyStack.Item>Content</Polaris.LegacyStack.Item>
 <PolarisLegacyStack.Item>Content</PolarisLegacyStack.Item>
@@ -21,8 +24,10 @@ import {LegacyStack as PolarisLegacyStack} from '@shopify/polaris';
 The following patterns are not warnings:
 
 ```js
-import {LegacyStack} from '@shopify/polaris';
+import {Stack, LegacyStack} from '@shopify/polaris';
 
+<Stack.Item fill><span>Content</span></Stack.Item>
+<Stack><span>No wrapping item</span></Stack>
 <LegacyStack.Item fill><span>Content</span></LegacyStack.Item>
 <LegacyStack><span>No wrapping item</span></LegacyStack>
 ```

--- a/packages/eslint-plugin/docs/rules/polaris-prefer-sectioned-prop.md
+++ b/packages/eslint-plugin/docs/rules/polaris-prefer-sectioned-prop.md
@@ -6,6 +6,7 @@ Polaris provides a convenience `sectioned` prop for some components that wraps t
 
 This rule currently Require the use of the `sectioned` prop over the `Section` subcomponent for the following components:
 
+* [`Card`](https://polaris.shopify.com/components/deprecated/card)
 * [`LegacyCard`](https://polaris.shopify.com/components/layout-and-structure/legacy-card)
 * [`Popover`](https://polaris.shopify.com/components/overlays/popover)
 * [`Layout`](https://polaris.shopify.com/components/layout-and-structure/layout)
@@ -15,8 +16,9 @@ This rule only takes effect when the `Section` subcomponent is the only top-leve
 The following patterns are considered warnings:
 
 ```js
-import {LegacyCard, Popover, Layout} from '@shopify/polaris';
+import {Card, LegacyCard, Popover, Layout} from '@shopify/polaris';
 
+<Card><Card.Section>Contents</Card.Section></Card>
 <LegacyCard><LegacyCard.Section>Contents</LegacyCard.Section></LegacyCard>
 <Popover><Popover.Section>Contents</Popover.Section></Popover>
 <Layout><Layout.Section>Contents</Layout.Section></Layout>
@@ -25,7 +27,13 @@ import {LegacyCard, Popover, Layout} from '@shopify/polaris';
 The following patterns are not warnings:
 
 ```js
-import {LegacyCard, Layout, Popover} from '@shopify/polaris';
+import {Card, LegacyCard, Layout, Popover} from '@shopify/polaris';
+
+<Card sectioned>Contents</Card>
+
+<Card>
+  <Card.Section subdued>Contents</Card.Section>
+</Card>
 
 <LegacyCard sectioned>Contents</LegacyCard>
 

--- a/packages/eslint-plugin/lib/rules/polaris-no-bare-stack-item.js
+++ b/packages/eslint-plugin/lib/rules/polaris-no-bare-stack-item.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     docs: {
       description:
-        'Disallow the use of Polaris’s `LegacyStack.Item` without any custom props.',
+        'Disallow the use of Polaris’s `Stack.Item` and `LegacyStack.Item` without any custom props.',
       category: 'Best Practices',
       recommended: true,
       uri: docsUrl('polaris-no-bare-stack-item'),
@@ -17,13 +17,13 @@ module.exports = {
       JSXElement(node) {
         const component = polarisComponentFromJSX(node, context);
         if (
-          component === 'LegacyStack.Item' &&
+          (component === 'Stack.Item' || component === 'LegacyStack.Item') &&
           node.openingElement.attributes.length === 0
         ) {
           context.report({
             node,
             message:
-              'You don’t need to wrap content in a LegacyStack.Item unless you need to customize one of its props.',
+              'You don’t need to wrap content in a Stack.Item or LegacyStack.Item unless you need to customize one of its props.',
           });
         }
       },

--- a/packages/eslint-plugin/lib/rules/polaris-prefer-sectioned-prop.js
+++ b/packages/eslint-plugin/lib/rules/polaris-prefer-sectioned-prop.js
@@ -1,6 +1,11 @@
 const {polarisComponentFromJSX, docsUrl} = require('../utilities');
 
-const COMPONENTS_WITH_SECTIONED_PROP = ['Popover', 'LegacyCard', 'Layout'];
+const COMPONENTS_WITH_SECTIONED_PROP = [
+  'Card',
+  'Popover',
+  'LegacyCard',
+  'Layout',
+];
 
 module.exports = {
   meta: {

--- a/packages/eslint-plugin/tests/lib/rules/polaris-no-bare-stack-item.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/polaris-no-bare-stack-item.test.js
@@ -14,7 +14,7 @@ const errors = [
   {
     type: 'JSXElement',
     message:
-      'You don’t need to wrap content in a LegacyStack.Item unless you need to customize one of its props.',
+      'You don’t need to wrap content in a Stack.Item or LegacyStack.Item unless you need to customize one of its props.',
   },
 ];
 
@@ -22,8 +22,24 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
   valid: [
     {
       code: `
+        import {Stack} from '@shopify/polaris';
+        <Stack>Content</Stack>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
         import {LegacyStack} from '@shopify/polaris';
         <LegacyStack>Content</LegacyStack>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
+        import {Stack} from '@shopify/polaris';
+        <Stack>Content<Stack.Item fill>More content</Stack.Item></Stack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
       parserOptions,
@@ -38,8 +54,24 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
     },
     {
       code: `
+        import {Stack} from 'other-module';
+        <Stack><Stack.Item>Content</Stack.Item></Stack>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
         import {LegacyStack} from 'other-module';
         <LegacyStack><LegacyStack.Item>Content</LegacyStack.Item></LegacyStack>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
+        import {Stack} from '@shopify/polaris';
+        <Stack.Item fill>Content</Stack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
       parserOptions,
@@ -56,6 +88,15 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
   invalid: [
     {
       code: `
+        import {Stack} from '@shopify/polaris';
+        <Stack><Stack.Item>Content</Stack.Item></Stack>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+      errors,
+    },
+    {
+      code: `
         import {LegacyStack} from '@shopify/polaris';
         <LegacyStack><LegacyStack.Item>Content</LegacyStack.Item></LegacyStack>;
       `,
@@ -65,8 +106,26 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
     },
     {
       code: `
+        import {Stack} from '@shopify/polaris';
+        <Stack.Item>Content</Stack.Item>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+      errors,
+    },
+    {
+      code: `
         import {LegacyStack} from '@shopify/polaris';
         <LegacyStack.Item>Content</LegacyStack.Item>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+      errors,
+    },
+    {
+      code: `
+        import * as P from '@shopify/polaris';
+        <P.Stack.Item>Content</P.Stack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
       parserOptions,

--- a/packages/eslint-plugin/tests/lib/rules/polaris-prefer-sectioned-prop.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/polaris-prefer-sectioned-prop.test.js
@@ -23,6 +23,14 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
   valid: [
     {
       code: `
+        import {Card} from '@shopify/other';
+        <Card><Card.Section /></Card>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
         import {LegacyCard} from '@shopify/other';
         <LegacyCard><LegacyCard.Section /></LegacyCard>;
       `,
@@ -39,8 +47,24 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
     },
     {
       code: `
+        import {Card} from '@shopify/polaris';
+        <Card />;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
         import {LegacyCard} from '@shopify/polaris';
         <LegacyCard />;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
+        import {Card} from '@shopify/polaris';
+        <Card>Content</Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
       parserOptions,
@@ -55,8 +79,24 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
     },
     {
       code: `
+        import {Card} from '@shopify/polaris';
+        <Card><Card.Section subdued /></Card>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
         import {LegacyCard} from '@shopify/polaris';
         <LegacyCard><LegacyCard.Section subdued /></LegacyCard>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
+        import {Card} from '@shopify/polaris';
+        <Card><Card.Section {...props} /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
       parserOptions,
@@ -71,8 +111,24 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
     },
     {
       code: `
+        import {Card} from '@shopify/polaris';
+        <Card><Card.Other /></Card>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
         import {LegacyCard} from '@shopify/polaris';
         <LegacyCard><LegacyCard.Other /></LegacyCard>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+    },
+    {
+      code: `
+        import {Card} from '@shopify/polaris';
+        <Card><Card.Section /><Card.Section /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
       parserOptions,
@@ -95,6 +151,15 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
     },
   ],
   invalid: [
+    {
+      code: `
+        import {Card} from '@shopify/polaris';
+        <Card><Card.Section /></Card>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+      errors: errorsFor('Card'),
+    },
     {
       code: `
         import {LegacyCard} from '@shopify/polaris';
@@ -125,11 +190,29 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
     {
       code: `
         import * as Polaris from '@shopify/polaris';
+        <Polaris.Card><Polaris.Card.Section /></Polaris.Card>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+      errors: errorsFor('Card'),
+    },
+    {
+      code: `
+        import * as Polaris from '@shopify/polaris';
         <Polaris.LegacyCard><Polaris.LegacyCard.Section /></Polaris.LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
       parserOptions,
       errors: errorsFor('LegacyCard'),
+    },
+    {
+      code: `
+        import Polaris from '@shopify/polaris';
+        <Polaris.Card><Polaris.Card.Section /></Polaris.Card>;
+      `,
+      filename: fixtureFile('polaris-app/index.js'),
+      parserOptions,
+      errors: errorsFor('Card'),
     },
     {
       code: `


### PR DESCRIPTION
## Description

Part of [Polaris#8185](https://github.com/Shopify/polaris/issues/8185).

A previous [PR](https://github.com/Shopify/web-configs/pull/371) updated the `polaris-no-bare-stack-item` to only support `LegacyStack`. Similarly, the `polaris-prefer-sectioned-prop` to only support `LegacyCard`, all in a patch release.

This updates those rules (along with documentation and tests) to support both `Card` and `Stack` along with their legacy counterparts, `LegacyCard` and `LegacyStack` in a minor release. More context [here](https://github.com/Shopify/web-configs/pull/371#issuecomment-1482160392).