### PR TITLE
Enable @typescript-eslint/consistent-type-imports

### DIFF
--- a/.changeset/fluffy-spoons-admire.md
+++ b/.changeset/fluffy-spoons-admire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': minor
+---
+
+Enable @typescript-eslint/consistent-type-imports to error

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -187,6 +187,8 @@ module.exports = {
         '@typescript-eslint/ban-ts-comment': 'error',
         // Enforce consistent brace style for blocks
         '@typescript-eslint/brace-style': 'error',
+        // Enforce consistent type imports when importing a token as strictly a type vs as a runtime value
+        '@typescript-eslint/consistent-type-imports': 'error',
         // Enforces consistent usage of type assertions.
         '@typescript-eslint/consistent-type-assertions': [
           'error',


### PR DESCRIPTION
This is a valuable rule to make it clear when a token being imported is used strictly for the type system vs a value at runtime.

https://typescript-eslint.io/rules/consistent-type-imports/

The rule is auto-fixable
