### PR TITLE
feat: move to eslint-plugin-n

### DIFF
--- a/packages/eslint-plugin/lib/config/node.js
+++ b/packages/eslint-plugin/lib/config/node.js
@@ -3,7 +3,7 @@ module.exports = {
     node: true,
   },
 
-  plugins: ['node'],
+  plugins: ['n'],
 
   rules: {
     // Those rules will be remove with ESLint 7.0. We use the one from
@@ -19,79 +19,79 @@ module.exports = {
     'no-restricted-modules': 'off',
     'no-sync': 'off',
     // Enforce return after a callback
-    'node/callback-return': ['error', ['callback', 'cb', 'next']],
+    'n/callback-return': ['error', ['callback', 'cb', 'next']],
     // Disallow require() outside of the top-level module scope
-    'node/global-require': 'off',
+    'n/global-require': 'off',
     // Enforces error handling in callbacks
-    'node/handle-callback-err': ['error', '^.*(e|E)rr(or)?$'],
+    'n/handle-callback-err': ['error', '^.*(e|E)rr(or)?$'],
     // Disallow use of the Buffer() constructor
     'no-buffer-constructor': 'error',
     // Disallow mixing regular variable and require declarations
-    'node/no-mixed-requires': 'off',
+    'n/no-mixed-requires': 'off',
     // Disallow use of new operator with the require function
-    'node/no-new-require': 'error',
+    'n/no-new-require': 'error',
     // Disallow string concatenation with __dirname and __filename
-    'node/no-path-concat': 'error',
+    'n/no-path-concat': 'error',
     // Disallow process.exit()
-    'node/no-process-exit': 'off',
+    'n/no-process-exit': 'off',
     // Restrict usage of specified node imports
-    'node/no-restricted-import': 'off',
+    'n/no-restricted-import': 'off',
     // Restrict usage of specified node modules
-    'node/no-restricted-require': 'off',
+    'n/no-restricted-require': 'off',
     // Disallow use of synchronous methods
-    'node/no-sync': 'off',
+    'n/no-sync': 'off',
     // Disallow import declarations of extraneous packages
     // defer to import/no-extraneous-dependencies
-    'node/no-extraneous-import': 'off',
+    'n/no-extraneous-import': 'off',
     // Disallow require() expressions of extraneous packages
     // defer to import/no-extraneous-dependencies
-    'node/no-extraneous-require': 'off',
+    'n/no-extraneous-require': 'off',
     // Enforce either module.exports or exports.
-    'node/exports-style': ['error', 'module.exports'],
+    'n/exports-style': ['error', 'module.exports'],
     // enforce either Buffer or require("buffer").Buffer
-    'node/prefer-global/buffer': 'error',
+    'n/prefer-global/buffer': 'error',
     //	enforce either console or require("console")
-    'node/prefer-global/console': 'error',
+    'n/prefer-global/console': 'error',
     // enforce either process or require("process")
-    'node/prefer-global/process': 'error',
+    'n/prefer-global/process': 'error',
     // enforce either TextDecoder or require("util").TextDecoder
-    'node/prefer-global/text-decoder': 'error',
+    'n/prefer-global/text-decoder': 'error',
     // enforce either TextEncoder or require("util").TextEncoder
-    'node/prefer-global/text-encoder': 'error',
+    'n/prefer-global/text-encoder': 'error',
     // enforce either URLSearchParams or require("url").URLSearchParams
-    'node/prefer-global/url-search-params': 'error',
+    'n/prefer-global/url-search-params': 'error',
     // enforce either URL or require("url").URL
-    'node/prefer-global/url': 'error',
+    'n/prefer-global/url': 'error',
     // Disallow deprecated API.
-    'node/no-deprecated-api': 'error',
+    'n/no-deprecated-api': 'error',
     // Disallow import and export declarations for files that don't exist.
-    'node/no-missing-import': 'off',
+    'n/no-missing-import': 'off',
     // Disallow require()s for files that don't exist.
-    'node/no-missing-require': 'off',
+    'n/no-missing-require': 'off',
     // Disallow import and export declarations for files that are not published.
-    'node/no-unpublished-import': 'off',
+    'n/no-unpublished-import': 'off',
     // Disallow bin files that npm ignores.
-    'node/no-unpublished-bin': 'error',
+    'n/no-unpublished-bin': 'error',
     // Disallow require()s for files that are not published.
-    'node/no-unpublished-require': 'off',
+    'n/no-unpublished-require': 'off',
     // disallow unsupported ECMAScript built-ins on the specified version
-    'node/no-unsupported-features/es-builtins': 'off',
+    'n/no-unsupported-features/es-builtins': 'off',
     // disallow unsupported ECMAScript syntax on the specified version
-    'node/no-unsupported-features/es-syntax': 'off',
+    'n/no-unsupported-features/es-syntax': 'off',
     // disallow unsupported Node.js built-in APIs on the specified version
-    'node/no-unsupported-features/node-builtins': 'error',
+    'n/no-unsupported-features/node-builtins': 'error',
     // If you turn this rule on, ESLint comes to address process.exit() as throw in code path analysis.
-    'node/process-exit-as-throw': 'off',
+    'n/process-exit-as-throw': 'off',
     // Suggest correct usage of shebang.
-    'node/shebang': 'error',
+    'n/shebang': 'error',
     // disallows callback API in favor of promise API for dns module
-    'node/prefer-promises/dns': 'error',
+    'n/prefer-promises/dns': 'error',
     // disallows callback API in favor of promise API for fs module
-    'node/prefer-promises/fs': 'error',
+    'n/prefer-promises/fs': 'error',
     // disallow the assignment to `exports`
-    'node/no-exports-assign': 'error',
+    'n/no-exports-assign': 'error',
     // Ensures the Node.js error-first callback pattern is followed
-    'node/no-callback-literal': 'error',
+    'n/no-callback-literal': 'error',
 
     'no-process-env': 'off',
     'no-console': 'off',

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-jest": "^25.3.0",
     "eslint-plugin-jest-formatting": "^3.1.0",
     "eslint-plugin-jsx-a11y": "^6.5.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-prettier": "^4.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2311,6 +2311,13 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+builtins@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/builtins/-/builtins-5.0.1.tgz#87f6db9ab0458be728564fa81d876d8d74552fa9"
+  integrity sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==
+  dependencies:
+    semver "^7.0.0"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -3203,10 +3210,10 @@ eslint-module-utils@^2.7.3:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-es@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
-  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+eslint-plugin-es@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz#f0822f0c18a535a97c3e714e89f88586a7641ec9"
+  integrity sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==
   dependencies:
     eslint-utils "^2.0.0"
     regexpp "^3.0.0"
@@ -3268,17 +3275,19 @@ eslint-plugin-jsx-a11y@^6.5.0:
     language-tags "^1.0.5"
     minimatch "^3.0.4"
 
-eslint-plugin-node@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
-  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+eslint-plugin-n@^15.7.0:
+  version "15.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz#e29221d8f5174f84d18f2eb94765f2eeea033b90"
+  integrity sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==
   dependencies:
-    eslint-plugin-es "^3.0.0"
-    eslint-utils "^2.0.0"
+    builtins "^5.0.1"
+    eslint-plugin-es "^4.1.0"
+    eslint-utils "^3.0.0"
     ignore "^5.1.1"
-    minimatch "^3.0.4"
-    resolve "^1.10.1"
-    semver "^6.1.0"
+    is-core-module "^2.11.0"
+    minimatch "^3.1.2"
+    resolve "^1.22.1"
+    semver "^7.3.8"
 
 eslint-plugin-prettier@^4.1.0:
   version "4.1.0"
@@ -4347,6 +4356,13 @@ is-ci@^3.0.1:
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
     ci-info "^3.2.0"
+
+is-core-module@^2.11.0:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.12.1.tgz#0c0b6885b6f80011c71541ce15c8d66cf5a4f9fd"
+  integrity sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==
+  dependencies:
+    has "^1.0.3"
 
 is-core-module@^2.2.0:
   version "2.8.0"
@@ -6603,7 +6619,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -6617,6 +6633,15 @@ resolve@^1.22.0:
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
     is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.22.1:
+  version "1.22.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
+  integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
+  dependencies:
+    is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -6712,15 +6737,29 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.0.0:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.8:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
eslint-plugin-n is a community maintained fork of eslint-plugin-node: https://github.com/eslint-community/eslint-plugin-n

It ensures that an important module like eslint-plugin-node is kept up to date, with both ESLint 8.x and with Node.js itself.

Full disclosure: I'm part of the ESLint Community Core Team.

## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
