### PR TITLE
Add missing peer dependencies in eslint-plugin and stylelint-plugin

### DIFF
--- a/.changeset/nervous-rules-destroy.md
+++ b/.changeset/nervous-rules-destroy.md
@@ -1,0 +1,6 @@
+---
+'@shopify/eslint-plugin': patch
+'@shopify/stylelint-plugin': patch
+---
+
+Adding missing transitive peerDependencies

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -50,7 +50,9 @@
     "pluralize": "^8.0.0"
   },
   "peerDependencies": {
-    "eslint": "^8.3.0"
+    "@babel/core": ">=7.11.0",
+    "eslint": "^8.3.0",
+    "prettier": ">=2.0.0"
   },
   "devDependencies": {
     "react": "^16.13.1",

--- a/packages/stylelint-plugin/package.json
+++ b/packages/stylelint-plugin/package.json
@@ -32,6 +32,7 @@
     "stylelint-scss": "^4.4.0"
   },
   "peerDependencies": {
+    "prettier": ">=2.0.0",
     "stylelint": ">=15.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

`@shopify/eslint-plugin` and `@shopify/stylelint-plugin` are missing peerDependencies on `@babel/core` and `prettier`.

While it's not a massive problem, it does make life harder for package managers when trying to optimize package installation, see [Implicit Transitive Peer Dependencies](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0).

yarn currently reports both of these packages as missing peer dependencies:
```
➤ YN0000: @shopify/eslint-plugin@npm:42.1.0 doesn't provide @babel/core, breaking the following requirements:
➤ YN0000: @babel/eslint-parser@npm:7.22.9 → >=7.11.0

➤ YN0000: @shopify/eslint-plugin@npm:42.1.0 doesn't provide prettier, breaking the following requirements:
➤ YN0000: eslint-plugin-prettier@npm:4.2.1 → >=2.0.0

➤ YN0000: @shopify/stylelint-plugin@npm:12.0.1 doesn't provide prettier, breaking the following requirements:
➤ YN0000: stylelint-prettier@npm:3.0.0 → >=2.0.0
```

Noted both changes as `patch`, because consumers will already have been required to fulfil these requirements, so it's not forcing them to upgrade or install new packages with potential breaking changes.