### PR TITLE
Fix prefer-class-properties to ignore constructor overload declarations

### DIFF
--- a/.changeset/healthy-llamas-mix.md
+++ b/.changeset/healthy-llamas-mix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': patch
+---
+
+Fix prefer-class-properties to ignore empty constructor overload declarations

--- a/packages/eslint-plugin/lib/rules/prefer-class-properties.js
+++ b/packages/eslint-plugin/lib/rules/prefer-class-properties.js
@@ -75,7 +75,8 @@ module.exports = {
       return classNode.body.body.find((propertyNode) => {
         return (
           propertyNode.type === 'MethodDefinition' &&
-          propertyNode.key.name === 'constructor'
+          propertyNode.key.name === 'constructor' &&
+          propertyNode.value.body
         );
       });
     }

--- a/packages/eslint-plugin/tests/lib/rules/prefer-class-properties.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-class-properties.test.js
@@ -3,7 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/prefer-class-properties');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
+  parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: {
     ecmaVersion: 6,
   },
@@ -127,6 +127,15 @@ ruleTester.run('prefer-class-properties', rule, {
       }`,
       options: ['always'],
     },
+    {
+      code: `class Foo {
+        constructor();
+        constructor() {
+          this.foo = {[foo]: 123};
+        }
+      }`,
+      options: ['always'],
+    },
   ],
   invalid: [
     {
@@ -237,6 +246,16 @@ ruleTester.run('prefer-class-properties', rule, {
     {
       code: `class Foo {
         constructor() {
+          this['foo'] = 123;
+        }
+      }`,
+      errors: assignErrors,
+      options: ['always'],
+    },
+    {
+      code: `class Foo {
+        constructor();
+        constructor(a: number) {
           this['foo'] = 123;
         }
       }`,


### PR DESCRIPTION
## Description

When used in a Typescript codebase, where constructor overloads/multiple signatures are definable, `prefer-class-properties` will throw an exception, as it currently assumes that there will only be one or zero constructor declarations in a class (which is true for JS, but not for TS).

So the following results in an exception when executing ESLint

```
class A {

    constructor();
    constructor(a: number = 0) {
        // ...
    }
}
```

because `getConstructor()` will find the empty constructor overload/signature first, and then subsequently fail when trying to access the body, which is `null`.

I've updated `getConstructor()` to ignore constructors with no body, so that the "real" constructor is found and analysed.
