### PR TITLE
Use Record instead of index signatures

### DIFF
--- a/.changeset/kind-monkeys-refuse.md
+++ b/.changeset/kind-monkeys-refuse.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': major
+---
+
+Change the @typescript-eslint/consistent-indexed-object-style rule to use default error settings, aka Record over index signature

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -264,10 +264,7 @@ module.exports = {
         // Requires that private members are marked as readonly if they're never modified outside of the constructor
         '@typescript-eslint/prefer-readonly': 'off',
         // This rule enforces a consistent way to define records.
-        '@typescript-eslint/consistent-indexed-object-style': [
-          'error',
-          'index-signature',
-        ],
+        '@typescript-eslint/consistent-indexed-object-style': 'error',
         // Disallows unnecessary constraints on generic types
         '@typescript-eslint/no-unnecessary-type-constraint': 'error',
 

--- a/packages/images/optimize.d.ts
+++ b/packages/images/optimize.d.ts
@@ -1,1 +1,1 @@
-export function svgOptions(): {[key: string]: unknown};
+export function svgOptions(): Record<string, unknown>;

--- a/packages/typescript-configs/definitions/styles.d.ts
+++ b/packages/typescript-configs/definitions/styles.d.ts
@@ -1,9 +1,9 @@
 declare module '*.scss' {
-  const classNames: {[key: string]: string};
+  const classNames: Record<string, string>;
   export default classNames;
 }
 
 declare module '*.css' {
-  const classNames: {[key: string]: string};
+  const classNames: Record<string, string>;
   export default classNames;
 }


### PR DESCRIPTION
## Description

This change makes it so that `@typescript-eslint/consistent-indexed-object-style` uses the default config for error, aka use a Record and not in index signature.

I created a snapshot and tested this in my repo. Here's a [video](https://screenshot.click/04-35-j739o-7elfe.mp4) showing that the switch worked and now it complains on index signatures.