### PR TITLE
Add support for `prefer-early-return` to detect when "if" statement is the last one in function body

### DIFF
--- a/packages/eslint-plugin/lib/rules/prefer-early-return.js
+++ b/packages/eslint-plugin/lib/rules/prefer-early-return.js
@@ -50,20 +50,20 @@ module.exports = {
     }
 
     function hasSimplifiableConditionalBody(functionBody) {
-      const body = functionBody.body;
-      return (
-        functionBody.type === 'BlockStatement' &&
-        body.length === 1 &&
-        isOffendingIfStatement(body[0])
-      );
+      if (!isBlockStatement(functionBody)) {
+        return false;
+      }
+
+      const lastStatement = getLastStatement(functionBody);
+      return Boolean(lastStatement) && isOffendingIfStatement(lastStatement);
     }
 
     function checkFunctionBody(functionNode) {
       const body = functionNode.body;
 
-      if (hasSimplifiableConditionalBody(body)) {
+      if (isBlockStatement(body) && hasSimplifiableConditionalBody(body)) {
         context.report(
-          body,
+          getLastStatement(body),
           'Prefer an early return to a conditionally-wrapped function body',
         );
       }
@@ -76,3 +76,13 @@ module.exports = {
     };
   },
 };
+
+function getLastStatement(statement) {
+  return 'body' in statement && statement.body.length > 0
+    ? statement.body[statement.body.length - 1]
+    : undefined;
+}
+
+function isBlockStatement(statement) {
+  return statement?.type === 'BlockStatement';
+}

--- a/packages/eslint-plugin/tests/lib/rules/prefer-early-return.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-early-return.test.js
@@ -6,7 +6,7 @@ const ruleTester = new RuleTester();
 
 const error = {
   message: 'Prefer an early return to a conditionally-wrapped function body',
-  type: 'BlockStatement',
+  type: 'IfStatement',
 };
 
 ruleTester.run('prefer-early-return', rule, {
@@ -142,6 +142,16 @@ ruleTester.run('prefer-early-return', rule, {
           doSomethingElse();
         }
       })`,
+      errors: [error],
+    },
+    {
+      code: `function foo() {
+        var bool = a && b;
+        if (bool) {
+          doSomething();
+          doSomethingElse();
+        }
+      }`,
       errors: [error],
     },
   ],


### PR DESCRIPTION
Sometimes we assign a conditions used in "if" test to a variable before "if" statement. In such case it's not the only statement in the block, but it should be detected anyway.

closes #314

## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `yarn changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->
