### PR TITLE
Replace deprecated `at-import-partial-extension` stylelint rule

### DIFF
--- a/.changeset/big-birds-live.md
+++ b/.changeset/big-birds-live.md
@@ -1,0 +1,5 @@
+---
+'@shopify/stylelint-plugin': patch
+---
+
+Replace deprecated `at-import-partial-extension` rule with `load-partial-extension`.

--- a/packages/stylelint-plugin/index.js
+++ b/packages/stylelint-plugin/index.js
@@ -553,7 +553,7 @@ module.exports = {
         'function-no-unknown': null,
         'scss/function-no-unknown': null,
         // Require or disallow extension in @import commands.
-        'scss/at-import-partial-extension': 'always',
+        'scss/load-partial-extension': 'always',
         // Disallow unknown at-rules. Should be used instead of stylelint's at-rule-no-unknown.
         'at-rule-no-unknown': null,
         'scss/at-rule-no-unknown': true,


### PR DESCRIPTION
## Description

This PR replaces the deprecated stylelint rule with it's replacement as per the warning messages when running stylelint:

```
Deprecation warnings:
 - The "scss/at-import-partial-extension" rule is deprecated.
 - 'at-import-partial-extension has been deprecated, and will be removed in '7.0'. Use 'load-partial-extension' instead. See: https://github.com/stylelint-scss/stylelint-scss/blob/v6.3.0/src/rules/at-import-partial-extension/README.md
```

The error message is helpful, but the link is not. The replacement rule is `load-partial-extension` and the docs for that are [here](https://github.com/stylelint-scss/stylelint-scss/tree/master/src/rules/load-partial-extension).