### PR TITLE
Replace usage of deprecated apis

### DIFF
--- a/.changeset/wet-buckets-accept.md
+++ b/.changeset/wet-buckets-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': minor
+---
+
+Replace usage of deprecated APIs that will be removed in ESLint v9

--- a/packages/eslint-plugin/lib/rules/binary-assignment-parens.js
+++ b/packages/eslint-plugin/lib/rules/binary-assignment-parens.js
@@ -30,12 +30,12 @@ module.exports = {
     const shouldHaveParens = config === 'always';
 
     function hasParens(node) {
-      const beforeToken = context.getTokenBefore(node);
+      const beforeToken = context.sourceCode.getTokenBefore(node);
       const hasBeforeParen =
         beforeToken &&
         beforeToken.type === 'Punctuator' &&
         beforeToken.value === '(';
-      const afterToken = context.getTokenAfter(node);
+      const afterToken = context.sourceCode.getTokenAfter(node);
       const hasAfterParen =
         afterToken &&
         afterToken.type === 'Punctuator' &&

--- a/packages/eslint-plugin/lib/rules/class-property-semi.js
+++ b/packages/eslint-plugin/lib/rules/class-property-semi.js
@@ -25,7 +25,7 @@ module.exports = {
     }
 
     function checkClassProperty(node) {
-      const lastToken = context.getLastToken(node);
+      const lastToken = context.sourceCode.getLastToken(node);
       const hasSemicolon = isSemicolon(lastToken);
 
       if (always && !hasSemicolon) {

--- a/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-content.js
+++ b/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-content.js
@@ -149,13 +149,14 @@ module.exports = {
   },
 };
 
-function getImportDetailsForJSX({openingElement}, context) {
+function getImportDetailsForJSX(node, context) {
+  const openingElement = node.openingElement;
   const isMemberExpression = openingElement.name.type === 'JSXMemberExpression';
   const searchForName = isMemberExpression
     ? openingElement.name.object.name
     : openingElement.name.name;
 
-  const importDetails = getImportDetailsForName(searchForName, context);
+  const importDetails = getImportDetailsForName(searchForName, context, node);
 
   if (importDetails == null) {
     return null;

--- a/packages/eslint-plugin/lib/rules/prefer-module-scope-constants.js
+++ b/packages/eslint-plugin/lib/rules/prefer-module-scope-constants.js
@@ -34,7 +34,7 @@ module.exports = {
           return;
         }
 
-        const scope = context.getScope();
+        const scope = context.sourceCode.getScope(node);
         if (!['module', 'global'].includes(scope.type)) {
           context.report(
             node,

--- a/packages/eslint-plugin/lib/rules/react-hooks-strict-return.js
+++ b/packages/eslint-plugin/lib/rules/react-hooks-strict-return.js
@@ -55,7 +55,7 @@ module.exports = {
         if (
           !exceedsMaxReturnProperties(
             node,
-            context.getScope(),
+            context.sourceCode.getScope(node),
             MAX_RETURN_ELEMENTS,
           )
         ) {

--- a/packages/eslint-plugin/lib/utilities/index.js
+++ b/packages/eslint-plugin/lib/utilities/index.js
@@ -35,8 +35,8 @@ function getName(node) {
 const DEFAULT_IMPORT = Symbol('default');
 const NAMESPACE_IMPORT = Symbol('namespace');
 
-function getImportDetailsForName(name, context) {
-  const definition = findDefinition(name, context);
+function getImportDetailsForName(name, context, node) {
+  const definition = findDefinition(name, context, node);
   if (definition == null || definition.type !== 'ImportBinding') {
     return null;
   }
@@ -100,9 +100,9 @@ function normalizeSource(source, context) {
   return normalized;
 }
 
-function findDefinition(name, context) {
+function findDefinition(name, context, node) {
   let definition = null;
-  let currentScope = context.getScope();
+  let currentScope = context.sourceCode.getScope(node);
 
   while (currentScope && !definition) {
     if (currentScope.set.has(name)) {
@@ -116,11 +116,16 @@ function findDefinition(name, context) {
   return definition;
 }
 
-function polarisComponentFromJSX({openingElement}, context) {
+function polarisComponentFromJSX(node, context) {
+  const openingElement = node.openingElement;
   const isMemberExpression = openingElement.name.type === 'JSXMemberExpression';
   const importDetails = isMemberExpression
-    ? getImportDetailsForName(getRootObject(openingElement.name).name, context)
-    : getImportDetailsForName(openingElement.name.name, context);
+    ? getImportDetailsForName(
+        getRootObject(openingElement.name).name,
+        context,
+        node,
+      )
+    : getImportDetailsForName(openingElement.name.name, context, node);
 
   if (importDetails == null || importDetails.source !== '@shopify/polaris') {
     return false;


### PR DESCRIPTION
## Description

Update deprecated APIs that have been removed in v9.
A minor version bump is fine, as our peerDependency version is `^8.56.0` which contains all the new APIs that we're using.

- `context.getTokenBefore(node)` becomes `context.sourceCode.getTokenBefore(node)`
- `context.getTokenAfter(node)` becomes `context.sourceCode.getTokenAfter(node)`
- `context.getLastToken(node)` becomes `context.sourceCode.getLastToken(node)`
- `context.getScope()` becomes `context.sourceCode.getScope(node)`