### PR TITLE
Remove babel parser and plugin

### DIFF
--- a/.changeset/weak-rats-explain.md
+++ b/.changeset/weak-rats-explain.md
@@ -1,0 +1,18 @@
+---
+'@shopify/eslint-plugin': major
+---
+
+Remove Babel parser and plugin.
+
+The Babel plugin and parser are only useful when authoring JavaScript that uses syntax that has not yet reached stage 4 of the standardisation process.
+
+We do not wish to encourage the usage of non-standard syntax in `.js` files as a default supported behaviour.
+
+If you wish to continue to use non-standard syntax in `.js` files then you should add and configure `@babel/eslint-parser` and `@babel/eslint-plugin` yourself.
+
+- ESLint v8's `semi` and `no-invalid-this` rules provide the behaviour that `@babel/semi`, `@babel/no-invalid-this` were introduced to solve, and thus the babel versions of these rules are no longer requried.
+- `@babel/new-cap` exists to handle the non-standard decorator syntax.
+- `@babel/object-curly-spacing` exists to handle non-standard `export x from "mod"` syntax.
+- `@babel/no-unused-expressions` exists to handle non-standard "do expressions".
+
+Remove all mentions of `@babel/*` rules in your eslint config unless you configure the babel plugin yourself.

--- a/packages/eslint-plugin/lib/config/esnext.js
+++ b/packages/eslint-plugin/lib/config/esnext.js
@@ -1,6 +1,4 @@
 const globals = require('globals');
-const babelParser = require('@babel/eslint-parser');
-const babelEslintPlugin = require('@babel/eslint-plugin');
 const promisePlugin = require('eslint-plugin-promise');
 const sortClassMembersPlugin = require('eslint-plugin-sort-class-members');
 const importPlugin = require('eslint-plugin-import');
@@ -11,11 +9,9 @@ module.exports = [
   ...shopifyCoreConfig,
   {
     languageOptions: {
-      parser: babelParser,
       parserOptions: {
-        ecmaVersion: '2021',
+        ecmaVersion: 'latest',
         sourceType: 'module',
-        requireConfigFile: false,
       },
       globals: {
         ...globals.es2021,
@@ -24,13 +20,9 @@ module.exports = [
 
     settings: {
       'import/ignore': ['node_modules', '\\.s?css'],
-      'import/parsers': {
-        '@babel/eslint-parser': ['.js', '.cjs', '.mjs', '.jsx'],
-      },
     },
 
     plugins: {
-      '@babel': babelEslintPlugin,
       promise: promisePlugin,
       'sort-class-members': sortClassMembersPlugin,
       import: importPlugin,
@@ -136,21 +128,6 @@ module.exports = [
       'promise/prefer-await-to-then': 'off',
       // Prefer async/await to the callback pattern
       'promise/prefer-await-to-callbacks': 'off',
-
-      //
-      // babel
-      //
-
-      // Ignores capitalized decorators (@Decorator)
-      '@babel/new-cap': ['error', {newIsCap: true, capIsNew: false}],
-      // Doesn't complain about export x from "mod"; or export * as x from "mod";
-      '@babel/object-curly-spacing': ['error', 'never'],
-      // Doesn't fail when inside class properties
-      '@babel/no-invalid-this': 'error',
-      // Doesn't fail when using do expressions or optional chaining
-      '@babel/no-unused-expressions': 'error',
-      // Rule to flag missing semicolons
-      '@babel/semi': 'error',
 
       //
       // sort-class-members

--- a/packages/eslint-plugin/lib/config/prettier.js
+++ b/packages/eslint-plugin/lib/config/prettier.js
@@ -12,8 +12,6 @@ module.exports = [
       'prettier/prettier': 'error',
 
       // rules to disable to prefer prettier
-      '@babel/semi': 'off',
-      '@babel/object-curly-spacing': 'off',
       '@shopify/class-property-semi': 'off',
       '@shopify/binary-assignment-parens': 'off',
       'prefer-arrow-callback': 'off',

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -287,11 +287,6 @@ module.exports = [
       'space-infix-ops': 'off',
       '@typescript-eslint/space-infix-ops': 'error',
 
-      // TypeScript provides a better mechanism (explicit `this` type)
-      // for ensuring proper `this` usage in functions not assigned to
-      // object properties.
-      '@babel/no-invalid-this': 'off',
-
       // Handled by TypeScript itself
       'no-undef': 'off',
       'no-unused-expressions': 'off',

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -25,8 +25,6 @@
   },
   "homepage": "https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/README.md",
   "dependencies": {
-    "@babel/eslint-parser": "^7.25.9",
-    "@babel/eslint-plugin": "^7.25.9",
     "@typescript-eslint/eslint-plugin": "^7.9.0",
     "@typescript-eslint/parser": "^7.9.0",
     "change-case": "^4.1.2",

--- a/packages/eslint-plugin/tests/lib/rules/class-property-semi.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/class-property-semi.test.js
@@ -3,7 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/class-property-semi');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
+  parserOptions: {ecmaVersion: 'latest'},
 });
 
 const classPropNoSemi = 'class Foo { bar = 1 }';

--- a/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-content.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-content.test.js
@@ -4,13 +4,10 @@ const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/jsx-no-hardcoded-content');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
   parserOptions: {
-    babelOptions: {
-      presets: [
-        ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
-      ],
-    },
+    ecmaVersion: 'latest',
+    ecmaFeatures: {jsx: true},
+    sourceType: 'module',
   },
 });
 

--- a/packages/eslint-plugin/tests/lib/rules/jsx-prefer-fragment-wrappers.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-prefer-fragment-wrappers.test.js
@@ -3,14 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/jsx-prefer-fragment-wrappers');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: {
-    babelOptions: {
-      presets: [
-        ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
-      ],
-    },
-  },
+  parserOptions: {ecmaVersion: 'latest', ecmaFeatures: {jsx: true}},
 });
 
 function errorWithTagName(tagName) {

--- a/packages/eslint-plugin/tests/lib/rules/no-fully-static-classes.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-fully-static-classes.test.js
@@ -3,7 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/no-fully-static-classes');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
+  parserOptions: {ecmaVersion: 'latest'},
 });
 
 function method(name = 'foo') {

--- a/packages/eslint-plugin/tests/lib/rules/no-useless-computed-properties.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-useless-computed-properties.test.js
@@ -3,10 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/no-useless-computed-properties');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: {
-    ecmaVersion: 6,
-  },
+  parserOptions: {ecmaVersion: 'latest'},
 });
 const message = 'Computed property is using a literal key unnecessarily.';
 

--- a/packages/eslint-plugin/tests/lib/rules/prefer-class-properties.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-class-properties.test.js
@@ -3,10 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/prefer-class-properties');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: {
-    ecmaVersion: 6,
-  },
+  parserOptions: {ecmaVersion: 'latest', sourceType: 'module'},
 });
 
 const classPropErrors = [

--- a/packages/eslint-plugin/tests/lib/rules/react-hooks-strict-return.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-hooks-strict-return.test.js
@@ -3,7 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-hooks-strict-return');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
+  parserOptions: {ecmaVersion: 'latest', sourceType: 'module'},
 });
 
 const errors = [

--- a/packages/eslint-plugin/tests/lib/rules/react-initialize-state.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-initialize-state.test.js
@@ -3,18 +3,9 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-initialize-state');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: {
-    babelOptions: {
-      presets: [
-        ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
-      ],
-    },
-  },
+  parser: require.resolve('@typescript-eslint/parser'),
   settings: {react: {version: 'detect'}},
 });
-
-const typeScriptParser = require.resolve('@typescript-eslint/parser');
 
 const errors = [
   {
@@ -82,54 +73,7 @@ ruleTester.run('react-initialize-state', rule, {
       }`,
     },
     {
-      code: 'class Button extends React.Component {}',
-      parser: typeScriptParser,
-    },
-    {
-      code: 'class Button extends React.Component<Props, {}> {}',
-      parser: typeScriptParser,
-    },
-    {
       code: 'class Button extends React.Component<Props, never> {}',
-      parser: typeScriptParser,
-    },
-    {
-      code: 'class Button extends React.Component<Props, any> {}',
-      parser: typeScriptParser,
-    },
-    {
-      code: `class Button extends React.Component<Props, {focused: boolean}> {
-        state = {focused: false};
-      }`,
-      parser: typeScriptParser,
-    },
-    {
-      code: `class Button extends React.Component<Props, State> {
-        state = {focused: false};
-      }`,
-      parser: typeScriptParser,
-    },
-    {
-      code: `class Button extends React.Component<Props, State> {
-        state = getState();
-      }`,
-      parser: typeScriptParser,
-    },
-    {
-      code: `class Button extends React.Component<Props, State> {
-        constructor() {
-          this.state = {focused: true};
-        }
-      }`,
-      parser: typeScriptParser,
-    },
-    {
-      code: `class Button extends React.Component<Props, State> {
-        constructor() {
-          this.state = getState();
-        }
-      }`,
-      parser: typeScriptParser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
@@ -137,7 +81,6 @@ ruleTester.run('react-initialize-state', rule, {
           (this as any).state = {};
         }
       }`,
-      parser: typeScriptParser,
     },
   ],
   invalid: [
@@ -197,51 +140,6 @@ ruleTester.run('react-initialize-state', rule, {
         class Button extends React.Component<Props, State> {}
         class OtherClass {}
       `,
-      errors,
-    },
-    {
-      code: 'class Button extends React.Component<Props, {focused: boolean}> {}',
-      parser: typeScriptParser,
-      errors,
-    },
-    {
-      code: `class Button extends React.Component<Props, {focused: boolean}> {
-        state = null;
-      }`,
-      parser: typeScriptParser,
-      errors,
-    },
-    {
-      code: `class Button extends React.Component<Props, State> {
-        states = {focused: false};
-      }`,
-      parser: typeScriptParser,
-      errors,
-    },
-    {
-      code: `class Button extends React.Component<Props, State> {
-        constructor() {
-          this.state = null;
-        }
-      }`,
-      parser: typeScriptParser,
-      errors,
-    },
-    {
-      code: `class Button extends React.Component<Props, State> {
-        constructor() {
-          this.states = {focused: true};
-        }
-      }`,
-      parser: typeScriptParser,
-      errors,
-    },
-    {
-      code: `
-        class Button extends React.Component<Props, State> {}
-        class OtherClass {}
-      `,
-      parser: typeScriptParser,
       errors,
     },
   ],

--- a/packages/eslint-plugin/tests/lib/rules/react-no-multiple-render-methods.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-no-multiple-render-methods.test.js
@@ -3,7 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-no-multiple-render-methods');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
+  parserOptions: {ecmaVersion: 'latest'},
   settings: {react: {version: 'detect'}},
 });
 

--- a/packages/eslint-plugin/tests/lib/rules/react-prefer-private-members.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-prefer-private-members.test.js
@@ -7,8 +7,6 @@ const ruleTester = new RuleTester({
   settings: {react: {version: 'detect'}},
 });
 
-const babelParser = require.resolve('@babel/eslint-parser');
-
 function makeError({type = 'PropertyDefinition', memberName, componentName}) {
   return {
     type,
@@ -29,11 +27,9 @@ ruleTester.run('react-prefer-private-members', rule, {
         publicMember = true
         publicMethod() {}
       }`,
-      parser: babelParser,
     },
     {
       code: 'class Button extends React.Component {}',
-      parser: babelParser,
     },
     {
       code: `class KitchenSink extends React.Component {
@@ -61,7 +57,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         componentWillUnmount() {}
         render() {}
       }`,
-      parser: babelParser,
     },
     {
       code: `class CompoundComponent extends React.Component {
@@ -70,7 +65,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         static AnotherItem = AnotherItem
         render() {}
       }`,
-      parser: babelParser,
     },
     {
       code: `class NormalClass {
@@ -82,7 +76,6 @@ ruleTester.run('react-prefer-private-members', rule, {
 
       get foo() {}
     }`,
-      parser: babelParser,
     },
   ],
   invalid: [
@@ -91,7 +84,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         publicMember = true;
         componentDidMount() {}
       }`,
-      parser: babelParser,
       errors: [
         makeError({memberName: 'publicMember', componentName: 'Button'}),
       ],
@@ -102,7 +94,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         static inValid = inValid;
         render() {}
       }`,
-      parser: babelParser,
       errors: [makeError({memberName: 'inValid', componentName: 'Button'})],
     },
     {
@@ -131,7 +122,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         publicMethod() {}
         componentDidMount() {}
       }`,
-      parser: babelParser,
       errors: [
         makeError({
           type: 'MethodDefinition',
@@ -145,7 +135,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         publicMethod() {}
         componentDidMount() {}
       }`,
-      parser: babelParser,
       errors: [
         makeError({
           type: 'MethodDefinition',
@@ -165,7 +154,6 @@ ruleTester.run('react-prefer-private-members', rule, {
 
       get foo() {}
     }`,
-      parser: babelParser,
       errors: [
         makeError({
           type: 'MethodDefinition',

--- a/packages/eslint-plugin/tests/lib/rules/react-require-autocomplete.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-require-autocomplete.test.js
@@ -3,14 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-require-autocomplete');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
-  parserOptions: {
-    babelOptions: {
-      presets: [
-        ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
-      ],
-    },
-  },
+  parserOptions: {ecmaVersion: 'latest', ecmaFeatures: {jsx: true}},
 });
 
 function errorMessage(componentName, tagName) {

--- a/packages/eslint-plugin/tests/lib/rules/webpack/no-unnamed-dynamic-imports.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/webpack/no-unnamed-dynamic-imports.test.js
@@ -3,7 +3,7 @@ const {RuleTester} = require('eslint');
 const rule = require('../../../../lib/rules/webpack/no-unnamed-dynamic-imports');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@babel/eslint-parser'),
+  parserOptions: {ecmaVersion: 'latest', sourceType: 'module'},
 });
 
 const CHUNK_NAME_REQUIRED =

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,22 +44,6 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/eslint-parser@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz#603c68a63078796527bc9d0833f5e52dd5f9224c"
-  integrity sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==
-  dependencies:
-    "@nicolo-ribaudo/eslint-scope-5-internals" "5.1.1-v1"
-    eslint-visitor-keys "^2.1.0"
-    semver "^6.3.1"
-
-"@babel/eslint-plugin@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-plugin/-/eslint-plugin-7.25.9.tgz#a5b6cc46085e0a7d45c5dae36055ce30c5125dab"
-  integrity sha512-MWg1lz+JiP9l1fXkE0qCUVo+1XwgNRPs6GTc88hmw6qN3AdgmfTSkyHt0e1xOTsKdXW5xlh2Lsk3wrFZbW5rzQ==
-  dependencies:
-    eslint-rule-composer "^0.3.0"
-
 "@babel/generator@^7.24.7", "@babel/generator@^7.7.2":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.24.7.tgz#1654d01de20ad66b4b4d99c135471bc654c55e6d"
@@ -1608,13 +1592,6 @@
     fs-extra "^8.1.0"
     globby "^11.0.0"
     read-yaml-file "^1.1.0"
-
-"@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
-  version "5.1.1-v1"
-  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
-  integrity sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==
-  dependencies:
-    eslint-scope "5.1.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3504,19 +3481,6 @@ eslint-plugin-sort-class-members@^1.21.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.21.0.tgz#e0ee1e5eddf698d5c997a071133b0cc51bb3de34"
   integrity sha512-QKV4jvGMu/ge1l4s1TUBC6rqqV/fbABWY7q2EeNpV3FRikoX6KuLhiNvS8UuMi+EERe0hKGrNU9e6ukFDxNnZQ==
 
-eslint-rule-composer@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
-  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
-
-eslint-scope@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
-  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
-  dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^4.1.1"
-
 eslint-scope@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
@@ -3524,11 +3488,6 @@ eslint-scope@^7.2.2:
   dependencies:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
-
-eslint-visitor-keys@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
-  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
 eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
@@ -3606,11 +3565,6 @@ esrecurse@^4.3.0:
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
-
-estraverse@^4.1.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
-  integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
 estraverse@^5.1.0, estraverse@^5.2.0, estraverse@^5.3.0:
   version "5.3.0"


### PR DESCRIPTION
## Description

Remove Babel parser and plugin.

The Babel plugin and parser are only useful when authoring JavaScript that uses syntax that has not yet reached stage 4 of the standardisation process.

We do not wish to encourage the usage of non-standard syntax in `.js` files as a default supported behaviour.

If you wish to continue to use non-standard syntax in `.js` files then you should add and configure `@babel/eslint-parser` and `@babel/eslint-plugin` yourself.

Remove all mentions of `@babel/*` rules in your eslint config unless you configure the babel parser/plugin yourself.

- ESLint v8's `semi` and `no-invalid-this` rules provide the behaviour that `@babel/semi`, `@babel/no-invalid-this` were introduced to solve, and thus the babel versions of these rules are no longer requried.
- `@babel/new-cap` exists to handle the non-standard decorator syntax.
- `@babel/object-curly-spacing` exists to handle non-standard `export x from "mod"` syntax.
- `@babel/no-unused-expressions` exists to handle non-standard "do expressions".