### PR TITLE
Always use the 'latest' ecmaVersion

### DIFF
--- a/.changeset/six-pianos-cheat.md
+++ b/.changeset/six-pianos-cheat.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': minor
+---
+
+Use the "latest" ecmaVersion when parsing

--- a/packages/eslint-plugin/lib/config/typescript-type-checking.js
+++ b/packages/eslint-plugin/lib/config/typescript-type-checking.js
@@ -8,7 +8,7 @@ module.exports = [
     languageOptions: {
       parser: typescriptEslintParser,
       parserOptions: {
-        ecmaVersion: 2021,
+        ecmaVersion: 'latest',
         sourceType: 'module',
       },
     },

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -17,7 +17,7 @@ module.exports = [
     languageOptions: {
       parser: typescriptEslintParser,
       parserOptions: {
-        ecmaVersion: 2021,
+        ecmaVersion: 'latest',
         sourceType: 'module',
       },
     },


### PR DESCRIPTION
Use the latest ecmaVersion instead of es2021.

I updated the ecmaVersion of the "esnext" config in #450, but missed doing this for ts files.