### PR TITLE
Migrate eslint tests to use FlatRuleTester

### DIFF
--- a/packages/eslint-plugin/tests/lib/rules/binary-assignment-parens.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/binary-assignment-parens.test.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/binary-assignment-parens');
 

--- a/packages/eslint-plugin/tests/lib/rules/class-property-semi.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/class-property-semi.test.js
@@ -1,10 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/class-property-semi');
 
-const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest'},
-});
+const ruleTester = new RuleTester();
 
 const classPropNoSemi = 'class Foo { bar = 1 }';
 const classPropWithSemi = 'class Foo { bar = 1; }';
@@ -23,7 +21,7 @@ ruleTester.run('class-property-semi', rule, {
       options: ['always'],
     },
     {code: classStaticPropNoSemi, options: ['never']},
-    {code: classMethod, parserOptions: {ecmaVersion: 6}},
+    {code: classMethod},
   ],
   invalid: [
     {

--- a/packages/eslint-plugin/tests/lib/rules/images-no-direct-imports.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/images-no-direct-imports.test.js
@@ -1,14 +1,9 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/images-no-direct-imports');
 
-const ruleTester = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: 'module',
-  },
-});
+const ruleTester = new RuleTester();
 
 function errors(type, folderPath, filePath) {
   return [
@@ -72,7 +67,7 @@ ruleTester.run('images-no-direct-imports', rule, {
     {
       code: "import * as icon1 from './icons/icon1.svg'",
       errors: errors('ImportDeclaration', './icons', './icons/icon1.svg'),
-      filename: fixtureFile('basic-app/app/components/Foo/index.js'),
+      filename: fixtureFile('basic-app/app/components/Foo/Foo.js'),
     },
     {
       code: "export {default as icon1} from './icons/icon1.svg'",

--- a/packages/eslint-plugin/tests/lib/rules/jest/no-all-mocks-methods.js
+++ b/packages/eslint-plugin/tests/lib/rules/jest/no-all-mocks-methods.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../../lib/rules/jest/no-all-mocks-methods');
 

--- a/packages/eslint-plugin/tests/lib/rules/jest/no-snapshots.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jest/no-snapshots.test.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../../lib/rules/jest/no-snapshots');
 

--- a/packages/eslint-plugin/tests/lib/rules/jsx-no-complex-expressions.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-no-complex-expressions.test.js
@@ -1,22 +1,24 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/jsx-no-complex-expressions');
 
-const ruleTester = new RuleTester();
-const parserOptions = {ecmaVersion: 6, ecmaFeatures: {jsx: true}};
+const ruleTester = new RuleTester({
+  languageOptions: {parserOptions: {ecmaFeatures: {jsx: true}}},
+});
+
 const errors = [
   {
     type: 'JSXExpressionContainer',
+    message:
+      'Don’t use conditional expressions inside JSX; they generally make your component harder to read. Instead, break that expression out into its own variable, and include the variable in JSX.',
   },
 ];
 
 ruleTester.run('jsx-no-complex-expressions', rule, {
   valid: [
-    {code: '<div title={foo} />', parserOptions},
-    {code: '<div title={condition && foo} />', parserOptions},
-    {code: '<div title={condition && foo || bar} />', parserOptions},
+    {code: '<div title={foo} />'},
+    {code: '<div title={condition && foo} />'},
+    {code: '<div title={condition && foo || bar} />'},
   ],
-  invalid: [
-    {code: '<div title={condition ? foo : bar} />', parserOptions, errors},
-  ],
+  invalid: [{code: '<div title={condition ? foo : bar} />', errors}],
 });

--- a/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-content.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-content.test.js
@@ -1,14 +1,10 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/jsx-no-hardcoded-content');
 
 const ruleTester = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 'latest',
-    ecmaFeatures: {jsx: true},
-    sourceType: 'module',
-  },
+  languageOptions: {parserOptions: {ecmaFeatures: {jsx: true}}},
 });
 
 function errorsFor(component, prop) {
@@ -44,7 +40,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
     },
     {code: '<MyComponent>{true}</MyComponent>'},
     {code: '<MyComponent>{2}</MyComponent>'},
-    {code: '<MyComponent>{true}</MyComponent>'},
     {
       code: '<MyComponent>Content</MyComponent>',
       options: [allowStrings],
@@ -102,10 +97,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
     },
     {
       code: "<MyComponent foo={'bar'} />",
-      options: [{...checkProps, ...allowStrings}],
-    },
-    {
-      code: '<MyComponent foo={`bar`} />',
       options: [{...checkProps, ...allowStrings}],
     },
     {

--- a/packages/eslint-plugin/tests/lib/rules/jsx-prefer-fragment-wrappers.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-prefer-fragment-wrappers.test.js
@@ -1,9 +1,9 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/jsx-prefer-fragment-wrappers');
 
 const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest', ecmaFeatures: {jsx: true}},
+  languageOptions: {parserOptions: {ecmaFeatures: {jsx: true}}},
 });
 
 function errorWithTagName(tagName) {

--- a/packages/eslint-plugin/tests/lib/rules/no-ancestor-directory-import.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-ancestor-directory-import.test.js
@@ -1,14 +1,9 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/no-ancestor-directory-import');
 
-const ruleTester = new RuleTester({
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: 'module',
-  },
-});
+const ruleTester = new RuleTester();
 
 const errors = [
   {

--- a/packages/eslint-plugin/tests/lib/rules/no-fully-static-classes.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-fully-static-classes.test.js
@@ -1,10 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/no-fully-static-classes');
 
-const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest'},
-});
+const ruleTester = new RuleTester();
 
 function method(name = 'foo') {
   return `${name}() {}`;

--- a/packages/eslint-plugin/tests/lib/rules/no-namespace-imports.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-namespace-imports.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/no-namespace-imports');
 

--- a/packages/eslint-plugin/tests/lib/rules/no-useless-computed-properties.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-useless-computed-properties.test.js
@@ -1,10 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/no-useless-computed-properties');
 
-const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest'},
-});
+const ruleTester = new RuleTester();
 const message = 'Computed property is using a literal key unnecessarily.';
 
 ruleTester.run('no-useless-computed-properties', rule, {

--- a/packages/eslint-plugin/tests/lib/rules/polaris-no-bare-stack-item.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/polaris-no-bare-stack-item.test.js
@@ -1,14 +1,11 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/polaris-no-bare-stack-item');
 
-const ruleTester = new RuleTester();
-const parserOptions = {
-  ecmaVersion: 6,
-  sourceType: 'module',
-  ecmaFeatures: {jsx: true},
-};
+const ruleTester = new RuleTester({
+  languageOptions: {parserOptions: {ecmaFeatures: {jsx: true}}},
+});
 
 const errors = [
   {
@@ -26,7 +23,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <Stack>Content</Stack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -34,7 +30,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <LegacyStack>Content</LegacyStack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -42,7 +37,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <Stack>Content<Stack.Item fill>More content</Stack.Item></Stack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -50,7 +44,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <LegacyStack>Content<LegacyStack.Item fill>More content</LegacyStack.Item></LegacyStack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -58,7 +51,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <Stack><Stack.Item>Content</Stack.Item></Stack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -66,7 +58,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <LegacyStack><LegacyStack.Item>Content</LegacyStack.Item></LegacyStack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -74,7 +65,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <Stack.Item fill>Content</Stack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -82,7 +72,6 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <LegacyStack.Item fill>Content</LegacyStack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
   ],
   invalid: [
@@ -92,7 +81,7 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <Stack><Stack.Item>Content</Stack.Item></Stack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors,
     },
     {
@@ -101,7 +90,7 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <LegacyStack><LegacyStack.Item>Content</LegacyStack.Item></LegacyStack>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors,
     },
     {
@@ -110,7 +99,7 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <Stack.Item>Content</Stack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors,
     },
     {
@@ -119,7 +108,7 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <LegacyStack.Item>Content</LegacyStack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors,
     },
     {
@@ -128,7 +117,7 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <P.Stack.Item>Content</P.Stack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors,
     },
     {
@@ -137,7 +126,7 @@ ruleTester.run('polaris-no-bare-stack-item', rule, {
         <P.LegacyStack.Item>Content</P.LegacyStack.Item>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors,
     },
   ],

--- a/packages/eslint-plugin/tests/lib/rules/polaris-prefer-sectioned-prop.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/polaris-prefer-sectioned-prop.test.js
@@ -1,14 +1,11 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/polaris-prefer-sectioned-prop');
 
-const ruleTester = new RuleTester();
-const parserOptions = {
-  ecmaVersion: 6,
-  sourceType: 'module',
-  ecmaFeatures: {jsx: true},
-};
+const ruleTester = new RuleTester({
+  languageOptions: {parserOptions: {ecmaFeatures: {jsx: true}}},
+});
 
 function errorsFor(component) {
   return [
@@ -27,7 +24,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card><Card.Section /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -35,7 +31,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard><LegacyCard.Section /></LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -43,7 +38,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <OtherComponent><OtherComponent.Section /></OtherComponent>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -51,7 +45,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card />;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -59,7 +52,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard />;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -67,7 +59,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card>Content</Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -75,7 +66,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard>Content</LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -83,7 +73,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card><Card.Section subdued /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -91,7 +80,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard><LegacyCard.Section subdued /></LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -99,7 +87,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card><Card.Section {...props} /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -107,7 +94,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard><LegacyCard.Section {...props} /></LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -115,7 +101,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card><Card.Other /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -123,7 +108,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard><LegacyCard.Other /></LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -131,7 +115,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card><Card.Section /><Card.Section /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -139,7 +122,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard><LegacyCard.Section /><LegacyCard.Section /></LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
     {
       code: `
@@ -147,7 +129,6 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Layout><Layout.AnnotatedSection /></Layout>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
     },
   ],
   invalid: [
@@ -157,7 +138,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Card><Card.Section /></Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('Card'),
     },
     {
@@ -166,7 +147,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <LegacyCard><LegacyCard.Section /></LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('LegacyCard'),
     },
     {
@@ -175,7 +156,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Popover><Popover.Section /></Popover>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('Popover'),
     },
     {
@@ -184,7 +165,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Layout><Layout.Section /></Layout>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('Layout'),
     },
     {
@@ -193,7 +174,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Polaris.Card><Polaris.Card.Section /></Polaris.Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('Card'),
     },
     {
@@ -202,7 +183,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Polaris.LegacyCard><Polaris.LegacyCard.Section /></Polaris.LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('LegacyCard'),
     },
     {
@@ -211,7 +192,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Polaris.Card><Polaris.Card.Section /></Polaris.Card>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('Card'),
     },
     {
@@ -220,7 +201,7 @@ ruleTester.run('polaris-prefer-sectioned-prop', rule, {
         <Polaris.LegacyCard><Polaris.LegacyCard.Section /></Polaris.LegacyCard>;
       `,
       filename: fixtureFile('polaris-app/index.js'),
-      parserOptions,
+
       errors: errorsFor('LegacyCard'),
     },
   ],

--- a/packages/eslint-plugin/tests/lib/rules/prefer-class-properties.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-class-properties.test.js
@@ -1,10 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/prefer-class-properties');
 
-const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest', sourceType: 'module'},
-});
+const ruleTester = new RuleTester();
 
 const classPropErrors = [
   {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-early-return.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-early-return.test.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/prefer-early-return');
 
@@ -74,18 +74,9 @@ ruleTester.run('prefer-early-return', rule, {
           doSomething();
         }
       }`,
-      parserOptions: {ecmaVersion: 6},
-    },
-    {
-      code: `var foo = function() {
-        if (something) {
-          doSomething();
-        }
-      }`,
     },
     {
       code: "var foo = () => 'bar'",
-      parserOptions: {ecmaVersion: 6},
     },
   ],
 
@@ -132,7 +123,6 @@ ruleTester.run('prefer-early-return', rule, {
           doSomethingElse();
         }
       }`,
-      parserOptions: {ecmaVersion: 6},
       errors: [error],
     },
     {

--- a/packages/eslint-plugin/tests/lib/rules/prefer-module-scope-constants.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-module-scope-constants.test.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/prefer-module-scope-constants');
 
@@ -19,28 +19,28 @@ const nonConstErrors = [
   },
 ];
 
-const supportedParserOptions = [
-  {ecmaVersion: 6, sourceType: 'module'},
-  {ecmaVersion: 6, sourceType: 'script'},
+const supportedLanguageOptions = [
+  {parserOptions: {sourceType: 'module'}},
+  {parserOptions: {sourceType: 'script'}},
 ];
 
-supportedParserOptions.forEach((parserOptions) => {
+supportedLanguageOptions.forEach((languageOptions) => {
   ruleTester.run('prefer-module-scope-constants', rule, {
     valid: [
-      {code: 'const FOO = true;', parserOptions},
-      {code: 'const foo = true;', parserOptions},
-      {code: '{ const foo = true; }', parserOptions},
-      {code: 'const foo = true, FOO = true;', parserOptions},
-      {code: 'const {FOO} = bar', parserOptions},
-      {code: '{ const {FOO} = bar; }', parserOptions},
-      {code: 'function foo() { const {FOO} = bar; }', parserOptions},
-      {code: '{ let {FOO} = bar; }', parserOptions},
-      {code: 'function foo() { let {FOO} = bar; }', parserOptions},
-      {code: 'const [FOO] = bar', parserOptions},
-      {code: '{ const [FOO] = bar; }', parserOptions},
-      {code: 'function foo() { const [FOO] = bar; }', parserOptions},
-      {code: '{ let [FOO] = bar; }', parserOptions},
-      {code: 'function foo() { let [FOO] = bar; }', parserOptions},
+      {code: 'const FOO = true;', languageOptions},
+      {code: 'const foo = true;', languageOptions},
+      {code: '{ const foo = true; }', languageOptions},
+      {code: 'const foo = true, FOO = true;', languageOptions},
+      {code: 'const {FOO} = bar', languageOptions},
+      {code: '{ const {FOO} = bar; }', languageOptions},
+      {code: 'function foo() { const {FOO} = bar; }', languageOptions},
+      {code: '{ let {FOO} = bar; }', languageOptions},
+      {code: 'function foo() { let {FOO} = bar; }', languageOptions},
+      {code: 'const [FOO] = bar', languageOptions},
+      {code: '{ const [FOO] = bar; }', languageOptions},
+      {code: 'function foo() { const [FOO] = bar; }', languageOptions},
+      {code: '{ let [FOO] = bar; }', languageOptions},
+      {code: 'function foo() { let [FOO] = bar; }', languageOptions},
       {
         code: `
           const MY_VALUE = true;
@@ -49,31 +49,35 @@ supportedParserOptions.forEach((parserOptions) => {
             console.log(MY_VALUE);
           };
         `,
-        parserOptions,
+        languageOptions,
       },
     ],
     invalid: [
-      {code: 'let FOO = true;', parserOptions, errors: nonConstErrors},
-      {code: '{ let FOO = true; }', parserOptions, errors: nonConstErrors},
+      {code: 'let FOO = true;', languageOptions, errors: nonConstErrors},
+      {code: '{ let FOO = true; }', languageOptions, errors: nonConstErrors},
       {
         code: 'function foo() { let FOO = true; }',
-        parserOptions,
+        languageOptions,
         errors: nonConstErrors,
       },
       {
         code: 'let foo = false, FOO = true;',
-        parserOptions,
+        languageOptions,
         errors: nonConstErrors,
       },
-      {code: '{ const FOO = true; }', parserOptions, errors: moduleScopeErrors},
+      {
+        code: '{ const FOO = true; }',
+        languageOptions,
+        errors: moduleScopeErrors,
+      },
       {
         code: 'function foo() { const FOO = true; }',
-        parserOptions,
+        languageOptions,
         errors: moduleScopeErrors,
       },
       {
         code: '{ const foo = false, FOO = true; }',
-        parserOptions,
+        languageOptions,
         errors: moduleScopeErrors,
       },
     ],

--- a/packages/eslint-plugin/tests/lib/rules/prefer-twine.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-twine.test.js
@@ -1,9 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/prefer-twine');
 
 const ruleTester = new RuleTester();
-const parserOptions = {ecmaVersion: 6, sourceType: 'module'};
 const errors = [
   {
     type: 'ImportDeclaration',
@@ -14,11 +13,11 @@ const errors = [
 
 ruleTester.run('prefer-twine', rule, {
   valid: [
-    {code: 'import Twine from "twine";', parserOptions},
-    {code: 'import foo from "bar"', parserOptions},
+    {code: 'import Twine from "twine";'},
+    {code: 'import foo from "bar"'},
   ],
   invalid: [
-    {code: 'import Bindings from "twine";', errors, parserOptions},
-    {code: 'import foo from "twine";', errors, parserOptions},
+    {code: 'import Bindings from "twine";', errors},
+    {code: 'import foo from "twine";', errors},
   ],
 });

--- a/packages/eslint-plugin/tests/lib/rules/react-hooks-strict-return.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-hooks-strict-return.test.js
@@ -1,10 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/react-hooks-strict-return');
 
-const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest', sourceType: 'module'},
-});
+const ruleTester = new RuleTester();
 
 const errors = [
   {

--- a/packages/eslint-plugin/tests/lib/rules/react-initialize-state.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-initialize-state.test.js
@@ -1,9 +1,10 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
+const typescriptParser = require('@typescript-eslint/parser');
 
 const rule = require('../../../lib/rules/react-initialize-state');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@typescript-eslint/parser'),
+  languageOptions: {parser: typescriptParser},
   settings: {react: {version: 'detect'}},
 });
 

--- a/packages/eslint-plugin/tests/lib/rules/react-no-multiple-render-methods.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-no-multiple-render-methods.test.js
@@ -1,9 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/react-no-multiple-render-methods');
 
 const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest'},
   settings: {react: {version: 'detect'}},
 });
 

--- a/packages/eslint-plugin/tests/lib/rules/react-prefer-private-members.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-prefer-private-members.test.js
@@ -1,9 +1,10 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
+const typescriptParser = require('@typescript-eslint/parser');
 
 const rule = require('../../../lib/rules/react-prefer-private-members');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@typescript-eslint/parser'),
+  languageOptions: {parser: typescriptParser},
   settings: {react: {version: 'detect'}},
 });
 

--- a/packages/eslint-plugin/tests/lib/rules/react-require-autocomplete.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-require-autocomplete.test.js
@@ -1,9 +1,9 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/react-require-autocomplete');
 
 const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest', ecmaFeatures: {jsx: true}},
+  languageOptions: {parserOptions: {ecmaFeatures: {jsx: true}}},
 });
 
 function errorMessage(componentName, tagName) {

--- a/packages/eslint-plugin/tests/lib/rules/react-type-state.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/react-type-state.test.js
@@ -1,9 +1,10 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
+const typescriptParser = require('@typescript-eslint/parser');
 
 const rule = require('../../../lib/rules/react-type-state');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@typescript-eslint/parser'),
+  languageOptions: {parser: typescriptParser},
   settings: {react: {version: 'detect'}},
 });
 

--- a/packages/eslint-plugin/tests/lib/rules/restrict-full-import.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/restrict-full-import.test.js
@@ -1,13 +1,8 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/restrict-full-import');
 
 const ruleTester = new RuleTester();
-
-const parserOptions = {
-  ecmaVersion: 2018,
-  sourceType: 'module',
-};
 
 const options = [['lodash']];
 
@@ -17,7 +12,6 @@ function configFor(type) {
   const message = `Unexpected full import of restricted module '${options[0][0]}'.`;
 
   return {
-    parserOptions,
     options,
     errors: [
       {
@@ -30,11 +24,11 @@ function configFor(type) {
 
 ruleTester.run('restrict-full-import', rule, {
   valid: [
-    {code: 'import {chain} from "lodash";', parserOptions, options},
-    {code: 'import _ from "something-else";', parserOptions, options},
-    {code: 'import chain from "lodash/chain";', parserOptions, options},
+    {code: 'import {chain} from "lodash";', options},
+    {code: 'import _ from "something-else";', options},
+    {code: 'import chain from "lodash/chain";', options},
     {code: 'var chain = require("lodash").chain;', options},
-    {code: 'var {chain} = require("lodash");', parserOptions, options},
+    {code: 'var {chain} = require("lodash");', options},
     {code: 'var chain = require("lodash/chain");', options},
     {code: 'var _ = require("something-else");', options},
   ],
@@ -66,14 +60,6 @@ ruleTester.run('restrict-full-import', rule, {
     },
     {
       code: 'var {chain, ...rest} = require("lodash");',
-      ...configFor('VariableDeclarator'),
-    },
-    {
-      code: 'var {chain, ...rest} = require("lodash");',
-      ...configFor('VariableDeclarator'),
-    },
-    {
-      code: 'var [chain, ...rest] = require("lodash");',
       ...configFor('VariableDeclarator'),
     },
     {

--- a/packages/eslint-plugin/tests/lib/rules/sinon-no-restricted-features.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/sinon-no-restricted-features.test.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/sinon-no-restricted-features');
 

--- a/packages/eslint-plugin/tests/lib/rules/sinon-prefer-meaningful-assertions.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/sinon-prefer-meaningful-assertions.test.js
@@ -1,4 +1,4 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const rule = require('../../../lib/rules/sinon-prefer-meaningful-assertions');
 

--- a/packages/eslint-plugin/tests/lib/rules/strict-component-boundaries.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/strict-component-boundaries.test.js
@@ -1,13 +1,9 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
 
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/strict-component-boundaries');
 
 const ruleTester = new RuleTester();
-const parserOptions = {
-  ecmaVersion: 6,
-  sourceType: 'module',
-};
 
 const errors = [
   {
@@ -20,57 +16,47 @@ ruleTester.run('strict-component-boundaries', rule, {
   valid: [
     {
       code: `import {someThing} from './components';`,
-      parserOptions,
       filename: fixtureFile('basic-app/app/index.js'),
     },
     {
       code: `import {someThing} from '../Bar';`,
-      parserOptions,
       filename: fixtureFile('basic-app/app/components/Foo/index.js'),
     },
     {
       code: `import {getDisplayName} from '@shopify/react-utilities/components';`,
-      parserOptions,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
     },
     {
       code: `import someUtility from './utilities/someUtility';`,
-      parserOptions,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
     },
     {
       code: `import someThing from './tests/fixtures/SomeMockQuery/query.json';`,
-      parserOptions,
       filename: fixtureFile('basic-app/app/components/Foo/index.js'),
     },
     {
       code: `import {someThing} from '../../components/Bar';`,
-      parserOptions,
       filename: fixtureFile('basic-app/app/components/Foo/index.js'),
     },
     {
       code: `import {someThing} from '../Baz';`,
-      parserOptions,
       filename: fixtureFile(
         'basic-app/app/components/Foo/components/Bar/index.js',
       ),
     },
     {
       code: `import {someThing} from '../../Foo.scss';`,
-      parserOptions,
       filename: fixtureFile(
         'basic-app/app/components/Foo/components/Bar/index.js',
       ),
     },
     {
       code: `import someThing from './components/Foo';`,
-      parserOptions,
       options: [{allow: ['components/\\w+$']}],
       filename: fixtureFile('basic-app/app/index.js'),
     },
     {
       code: `import someThing from './components/Foo';`,
-      parserOptions,
       options: [{maxDepth: 2}],
       filename: fixtureFile('basic-app/app/index.js'),
     },
@@ -78,38 +64,32 @@ ruleTester.run('strict-component-boundaries', rule, {
   invalid: [
     {
       code: `import someThing from './components/Foo';`,
-      parserOptions,
       errors,
       filename: fixtureFile('basic-app/app/index.js'),
     },
     {
       code: `import someThing from '../Bar/any-path';`,
-      parserOptions,
       errors,
       filename: fixtureFile('basic-app/app/components/Foo/index.js'),
     },
     {
       code: `import someThing from './components/Bar/any-path';`,
-      parserOptions,
       errors,
       filename: fixtureFile('basic-app/app/index.js'),
     },
     {
       code: `import someThing from '../Bar/tests/fixtures/SomeMockQuery/query.json';`,
-      parserOptions,
       errors,
       filename: fixtureFile('basic-app/app/components/Foo/index.js'),
     },
     {
       code: `import someThing from './components/Foo/Foo';`,
-      parserOptions,
       options: [{allow: ['components/\\w+$']}],
       errors,
       filename: fixtureFile('basic-app/app/index.js'),
     },
     {
       code: `import someThing from './components/Foo/Foo';`,
-      parserOptions,
       options: [{maxDepth: 2}],
       errors,
       filename: fixtureFile('basic-app/app/index.js'),

--- a/packages/eslint-plugin/tests/lib/rules/typescript/prefer-build-client-schema.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/typescript/prefer-build-client-schema.test.js
@@ -1,13 +1,10 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
+const typescriptParser = require('@typescript-eslint/parser');
 
 const rule = require('../../../../lib/rules/typescript/prefer-build-client-schema');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@typescript-eslint/parser'),
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: 'module',
-  },
+  languageOptions: {parser: typescriptParser},
 });
 
 function error() {

--- a/packages/eslint-plugin/tests/lib/rules/typescript/prefer-pascal-case-enums.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/typescript/prefer-pascal-case-enums.test.js
@@ -1,9 +1,10 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
+const typescriptParser = require('@typescript-eslint/parser');
 
 const rule = require('../../../../lib/rules/typescript/prefer-pascal-case-enums');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@typescript-eslint/parser'),
+  languageOptions: {parser: typescriptParser},
 });
 
 function errorWithName(name) {

--- a/packages/eslint-plugin/tests/lib/rules/typescript/prefer-singular-enums.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/typescript/prefer-singular-enums.test.js
@@ -1,9 +1,10 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
+const typescriptParser = require('@typescript-eslint/parser');
 
 const rule = require('../../../../lib/rules/typescript/prefer-singular-enums');
 
 const ruleTester = new RuleTester({
-  parser: require.resolve('@typescript-eslint/parser'),
+  languageOptions: {parser: typescriptParser},
 });
 
 function errorWithName(name) {

--- a/packages/eslint-plugin/tests/lib/rules/webpack/no-unnamed-dynamic-imports.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/webpack/no-unnamed-dynamic-imports.test.js
@@ -1,10 +1,9 @@
-const {RuleTester} = require('eslint');
+const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');
+const typescriptParser = require('@typescript-eslint/parser');
 
 const rule = require('../../../../lib/rules/webpack/no-unnamed-dynamic-imports');
 
-const ruleTester = new RuleTester({
-  parserOptions: {ecmaVersion: 'latest', sourceType: 'module'},
-});
+const ruleTester = new RuleTester();
 
 const CHUNK_NAME_REQUIRED =
   'imports should have a webpackChunkName (https://webpack.js.org/api/module-methods/#import-)';
@@ -57,18 +56,16 @@ ruleTester.run('webpack/no-unnamed-dynamic-imports', rule, {
         ).then(bar => bar);
       }
       `,
-      parser: require.resolve('@typescript-eslint/parser'),
+      languageOptions: {parser: typescriptParser},
     },
   ],
   invalid: [
     {
       code: `function foo() { import('bar'); }`,
-      options: ['never'],
       errors: [CHUNK_NAME_REQUIRED],
     },
     {
       code: `function foo() { System.import('bar'); }`,
-      options: ['never'],
       errors: [CHUNK_NAME_REQUIRED],
     },
     {
@@ -78,7 +75,6 @@ ruleTester.run('webpack/no-unnamed-dynamic-imports', rule, {
           'bar'
         );
       `,
-      options: ['never'],
       errors: ['webpackChunkName must be in a /* */ block comment'],
     },
   ],


### PR DESCRIPTION
## Description

Migrate ESLint tests to use `FlatRuleTester` in preparation for ESLint v9.

The new FlatRuleTester has a default `ecmaVersion` of `latest` and a default `sourceType` of `module` so we don't need to specify those in the tests.
It also identifies tests that are duplicates, and cases with invalid options and forces you to remove them. Some test cases were identified as duplicates and thus were removed.

When we move to eslint v9 we'll need to replace `const {FlatRuleTester: RuleTester} = require('eslint/use-at-your-own-risk');` with `const {RuleTester} = require('eslint');`


---

No changelog needed for this, as it only affects test files.