### PR TITLE
Update usage of deprecated `superTypeParameters`

### DIFF
--- a/.changeset/neat-clocks-juggle.md
+++ b/.changeset/neat-clocks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': minor
+---
+
+Replace usage of deprecated `superTypeParameters` with `superTypeArguments`

--- a/packages/eslint-plugin/lib/rules/react-initialize-state.js
+++ b/packages/eslint-plugin/lib/rules/react-initialize-state.js
@@ -70,24 +70,24 @@ module.exports = {
   },
 };
 
-function classHasEmptyStateType({superTypeParameters}) {
+function classHasEmptyStateType({superTypeArguments}) {
   const hasNoStateType =
-    !superTypeParameters ||
-    superTypeParameters.params.length < 2 ||
-    superTypeParameters.params[1].type === 'TSNeverKeyword' ||
-    superTypeParameters.params[1].type === 'TSAnyKeyword' ||
-    superTypeParameters.params[1].type === 'AnyTypeAnnotation';
+    !superTypeArguments ||
+    superTypeArguments.params.length < 2 ||
+    superTypeArguments.params[1].type === 'TSNeverKeyword' ||
+    superTypeArguments.params[1].type === 'TSAnyKeyword' ||
+    superTypeArguments.params[1].type === 'AnyTypeAnnotation';
 
   if (hasNoStateType) {
     return true;
   }
 
-  if (superTypeParameters.params[1].type === 'ObjectTypeAnnotation') {
-    return superTypeParameters.params[1].properties.length === 0;
+  if (superTypeArguments.params[1].type === 'ObjectTypeAnnotation') {
+    return superTypeArguments.params[1].properties.length === 0;
   }
 
-  if (superTypeParameters.params[1].type === 'TSTypeLiteral') {
-    return superTypeParameters.params[1].members.length === 0;
+  if (superTypeArguments.params[1].type === 'TSTypeLiteral') {
+    return superTypeArguments.params[1].members.length === 0;
   }
 
   return false;

--- a/packages/eslint-plugin/lib/rules/react-type-state.js
+++ b/packages/eslint-plugin/lib/rules/react-type-state.js
@@ -18,10 +18,10 @@ module.exports = {
     function looksLikeTypeScriptComponent(node) {
       return (
         isES6Component(node, context) &&
-        Boolean(node.superTypeParameters) &&
-        Boolean(node.superTypeParameters.params) &&
-        node.superTypeParameters.params.length > 0 &&
-        node.superTypeParameters.params[0].type === 'TSTypeReference'
+        Boolean(node.superTypeArguments) &&
+        Boolean(node.superTypeArguments.params) &&
+        node.superTypeArguments.params.length > 0 &&
+        node.superTypeArguments.params[0].type === 'TSTypeReference'
       );
     }
 


### PR DESCRIPTION

Update usage of deprecated `superTypeParameters`.

`superTypeParameters` was deprecated in favour of `superTypeArguments` in typescript-eslint v6 and is fully removed in typescript-eslint v9.

See https://github.com/typescript-eslint/typescript-eslint/pull/8933