### PR TITLE
Stop disabling rules now that their babel counterparts are removed

### DIFF
--- a/.changeset/stale-glasses-build.md
+++ b/.changeset/stale-glasses-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': minor
+---
+
+Stop disabling rules that existed because we used their babel counterparts

--- a/packages/eslint-plugin/lib/config/esnext.js
+++ b/packages/eslint-plugin/lib/config/esnext.js
@@ -276,15 +276,6 @@ module.exports = [
 
       // default params
       'no-param-reassign': 'error',
-      // Rules override by the Babel plugin
-      camelcase: 'off',
-      quotes: 'off',
-      'no-unused-expressions': 'off',
-      'valid-typeof': 'off',
-      'new-cap': 'off',
-      'no-await-in-loop': 'off',
-      'object-curly-spacing': 'off',
-      'no-invalid-this': 'off',
     },
   },
 ];


### PR DESCRIPTION
## Description

Follow up to #450.

Remove disabling rules that were disabled because we used the babel versions of the rules.

Now we're no longer using the babel versions of the rules, these rules don't need to be disabled in the esnext build. We shall use the values from the core config for these rules.


We end defer to what is configured within the `core` config for these rules:
- `new-cap`, `object-curly-spacing`, `no-unused-expressions` and `semi` are enabled in `core` and their config already matched how the babel version of the rules were configured
- `no-await-in-loop` is disabled in `core` - no change here
- `valid-typeof` is enabled in `core`. A babel version of that rule no longer exists so disabling it seems to have been some missed tidying.
- `no-invalid-this` is now disabled. Previously the babel version of the rule was enabled. This rule is already disabled in the typescript configs so if you're using TS then this has no effect.
- `camelcase` and `quotes` are enabled per their config in `core`. These rules are deprecated in ESLint v9 so we'll be removing their configuration in core soon anyway.
