### PR TITLE
Remove configuring deprecated formatting rules

### DIFF
--- a/.changeset/seven-pans-pay.md
+++ b/.changeset/seven-pans-pay.md
@@ -1,0 +1,89 @@
+---
+'@shopify/eslint-plugin': major
+---
+
+Remove configuration of deprecated formatting rules.
+
+Per https://eslint.org/blog/2023/10/deprecating-formatting-rules/ and https://typescript-eslint.io/blog/deprecating-formatting-rules several formatting related rules have been deprecated from `eslint` core and `typescript-eslint` and moved into `@stylistic/eslint-plugin`. These rules are removed in typescript-eslint v8 (released) and probably eslint v10 (unreleased).
+
+To prepare for future updates we are removing our configuration of these rules. We recommend that you use Prettier (https://prettier.io/) for formatting considerations - either by running it in parallel with ESLint or as part of ESLint through using `eslint-plugin-prettier` via the `prettier` config provided by `@shopify/eslint-plugin`. If you do not wish to use Prettier, then we suggest you configure rules from `@stylistic/eslint-plugin` (https://eslint.style/packages/default).
+
+Note that if you already use the `prettier` config then this removal will have no effect as all these rules were already turned off.
+
+Configuration for the following rules in the `es5`, `esnext` and `typescript` configs have been removed:
+
+From `typescript-eslint`:
+
+- @typescript-eslint/brace-style
+- @typescript-eslint/func-call-spacing
+- @typescript-eslint/indent
+- @typescript-eslint/keyword-spacing
+- @typescript-eslint/member-delimiter-style
+- @typescript-eslint/no-extra-parens
+- @typescript-eslint/quotes
+- @typescript-eslint/semi
+- @typescript-eslint/space-infix-ops
+- @typescript-eslint/type-annotation-spacing
+
+From ESLint core:
+
+- array-bracket-spacing
+- arrow-parens
+- arrow-spacing
+- block-spacing
+- brace-style
+- comma-dangle
+- comma-spacing
+- comma-style
+- computed-property-spacing
+- dot-location
+- eol-last
+- func-call-spacing
+- function-paren-newline
+- generator-star-spacing
+- indent-legacy
+- jsx-quotes
+- key-spacing
+- keyword-spacing
+- lines-around-comment
+- lines-between-class-members
+- max-statements-per-line
+- new-parens
+- newline-per-chained-call
+- no-confusing-arrow
+- no-extra-semi
+- no-floating-decimal
+- no-mixed-operators
+- no-mixed-spaces-and-tabs
+- no-multi-spaces
+- no-multiple-empty-lines
+- no-tabs
+- no-trailing-spaces
+- no-whitespace-before-property
+- object-curly-spacing
+- one-var-declaration-per-line
+- operator-linebreak
+- padding-line-between-statements
+- quote-props
+- quotes
+- rest-spread-spacing
+- semi
+- semi-spacing
+- semi-style
+- space-before-blocks
+- space-before-function-paren
+- space-in-parens
+- space-infix-ops
+- space-unary-ops
+- spaced-comment
+- switch-colon-spacing
+- template-curly-spacing
+- template-tag-spacing
+- wrap-iife
+- yield-star-spacing
+
+We retain configuration for the following rules for the moment - even though they are depreated - as prettier does not have opinions about whitespace in these cases:
+
+- lines-between-class-members
+- padding-line-between-statements
+- spaced-comment

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -40,6 +40,8 @@ $ npm install @shopify/eslint-plugin --save-dev
 
 As of version 46.0.0, this package uses Eslint's "Flat Config" format, not the legacy "eslintrc" format. To upgrade your Eslint configuration, follow the [Configuration Migration Guide](https://eslint.org/docs/latest/use/configure/migration-guide).
 
+As of version 47.0.0, this package no longer configures formatting related fules in the `es5`, `esnext` and `typescript` configs, as ESLint [depreacated their formatting related rules](https://eslint.org/blog/2023/10/deprecating-formatting-rules/).
+
 ---
 
 Shopify’s ESLint configs come bundled in this package. In order to use them, you include the relevant configurations in your project’s `eslint.config.js`. For example, the following will use the ESNext (ES2015 and later) config:
@@ -170,3 +172,5 @@ This plugin provides the following custom rules, which are included as appropria
 ## Suggested additional configs
 
 For applications that use graphql we recommend using the `operations-recommended` preset from [`@graphql-eslint/eslint-plugin`](https://github.com/B2o5T/graphql-eslint). This is not included as part of this plugin because graphql has a large install footprint and not everybody needs it.
+
+For applications that wish to have code formatting opinions, we strongly suggest using `prettier`, and either format with `prettier`'s CLI after running eslint, or run prettier within eslint by using the `prettier` config. If you wish to diverge from this then you can configure formatting using the rules from [`@stylistic/eslint-plugin`](https://eslint.style/packages/default) package.

--- a/packages/eslint-plugin/lib/config/core.js
+++ b/packages/eslint-plugin/lib/config/core.js
@@ -32,8 +32,6 @@ module.exports = [
       'default-case': 'off',
       // Encourages use of dot notation whenever possible
       'dot-notation': ['error', {allowKeywords: true}],
-      // Enforces consistent newlines before or after dots
-      'dot-location': ['error', 'property'],
       // Require the use of === and !==
       eqeqeq: ['error', 'allow-null'],
       // Make sure for-in loops have an if statement
@@ -66,8 +64,6 @@ module.exports = [
       'no-extra-label': 'error',
       // Disallow fallthrough of case statements
       'no-fallthrough': 'error',
-      // Disallow the use of leading or trailing decimal points in numeric literals
-      'no-floating-decimal': 'error',
       // Disallow reassignments of native objects
       'no-global-assign': 'error',
       // Disallow the type conversions with shorter notations
@@ -88,8 +84,6 @@ module.exports = [
       'no-loop-func': 'error',
       // Disallow the use of magic numbers
       'no-magic-numbers': 'off',
-      // Disallow use of multiple spaces
-      'no-multi-spaces': 'error',
       // Disallow use of multiline strings
       'no-multi-str': 'off',
       // Disallow use of new operator for Function object
@@ -161,8 +155,6 @@ module.exports = [
       'require-unicode-regexp': 'off',
       // Requires to declare all vars on top of their containing scope
       'vars-on-top': 'off',
-      // Require immediate function invocation to be wrapped in parentheses
-      'wrap-iife': ['error', 'inside'],
       // Require or disallow Yoda conditions
       yoda: ['error', 'never'],
       // Disallow returning value from constructor
@@ -176,8 +168,6 @@ module.exports = [
 
       // Specify the maximum depth that blocks can be nested
       'max-depth': 'off',
-      // Specify the maximum length of a line in your program
-      'max-len': 'off',
       // Limits the number of parameters that can be used in the function declaration.
       'max-params': ['error', 10],
       // Specify the maximum number of statement allowed in a function
@@ -225,10 +215,6 @@ module.exports = [
       'no-ex-assign': 'error',
       // Disallow double-negation boolean casts in a boolean context
       'no-extra-boolean-cast': 'error',
-      // Disallow unnecessary parentheses
-      'no-extra-parens': 'off',
-      // Disallow unnecessary semicolons
-      'no-extra-semi': 'error',
       // Disallow overwriting functions written as function declarations
       'no-func-assign': 'error',
       // Disallow function or variable declarations in nested blocks
@@ -351,51 +337,18 @@ module.exports = [
       // stylistic issues
       //
 
-      // enforce linebreaks after opening and before closing array brackets
-      'array-bracket-newline': 'off',
-      // Enforce spacing inside array brackets
-      'array-bracket-spacing': ['error', 'never'],
-      // enforce line breaks after each array element
-      'array-element-newline': 'off',
-      // Disallow or enforce spaces inside of single line blocks
-      'block-spacing': ['error', 'always'],
-      // Enforce one true brace style
-      'brace-style': ['error', '1tbs', {allowSingleLine: true}],
       // Require camel case names
       camelcase: ['error', {properties: 'always'}],
       // Enforce or disallow capitalization of the first letter of a comment
       'capitalized-comments': 'off',
-      // Disallow or enforce trailing commas
-      'comma-dangle': [
-        'error',
-        {
-          arrays: 'always-multiline',
-          objects: 'always-multiline',
-          imports: 'always-multiline',
-          exports: 'always-multiline',
-          functions: 'always-multiline',
-        },
-      ],
-      // Enforce spacing before and after comma
-      'comma-spacing': ['error', {before: false, after: true}],
-      // Enforce one true comma style
-      'comma-style': ['error', 'last'],
-      // Require or disallow padding inside computed properties
-      'computed-property-spacing': ['error', 'never'],
       // Enforces consistent naming when capturing the current execution context
       'consistent-this': ['error', 'self'],
-      // Enforce newline at the end of file, with no multiple empty lines
-      'eol-last': 'error',
-      // Disallow space between function identifier and application
-      'func-call-spacing': 'error',
       // Require function names to match the name of the variable or property to which they are assigned
       'func-name-matching': 'error',
       // Don't require function expressions to have a name
       'func-names': 'off',
       // Enforces use of function declarations or expressions
       'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
-      // enforce consistent line breaks inside function parentheses
-      'function-paren-newline': ['error', 'consistent'],
       // Blacklist certain identifiers to prevent them being used
       'id-blacklist': 'off',
       // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
@@ -409,28 +362,6 @@ module.exports = [
       ],
       // Require identifiers to match the provided regular expression
       'id-match': 'off',
-      // Enforce a consistent location for an arrow function containing an implicit return
-      'implicit-arrow-linebreak': 'off',
-      // Disable eslint v4 stricter indent rules
-      indent: 'off',
-      // Use eslint v3 indent rules: This option sets a specific tab width for your code
-      'indent-legacy': ['error', 2, {SwitchCase: 1, MemberExpression: 1}],
-      // Specify whether double or single quotes should be used in JSX attributes
-      'jsx-quotes': ['error', 'prefer-double'],
-      // Enforces spacing between keys and values in object literal properties
-      'key-spacing': ['error', {beforeColon: false, afterColon: true}],
-      // Enforce spacing before and after keywords
-      'keyword-spacing': ['error', {before: true, after: true, overrides: {}}],
-      // Disallow mixed "LF" and "CRLF" as linebreaks
-      'linebreak-style': 'off',
-      // Enforces empty lines around comments
-      'lines-around-comment': ['error', {beforeBlockComment: true}],
-      // require or disallow an empty line between class members
-      'lines-between-class-members': [
-        'error',
-        'always',
-        {exceptAfterSingleLine: true},
-      ],
       // Enforce position of line comments
       'line-comment-position': ['error', {position: 'above'}],
       // Enforce a maximum file length
@@ -439,22 +370,14 @@ module.exports = [
       'max-lines-per-function': 'off',
       // Specify the maximum depth callbacks can be nested
       'max-nested-callbacks': 'off',
-      // Specify the maximum number of statements allowed per line
-      'max-statements-per-line': ['error', {max: 2}],
       // enforce a particular style for multiline comments
       'multiline-comment-style': 'off',
-      // Enforce newlines between operands of ternary expressions
-      'multiline-ternary': 'off',
       // Require a capital letter for constructors
       'new-cap': ['error', {newIsCap: true, capIsNew: false}],
-      // Disallow the omission of parentheses when invoking a constructor with no arguments
-      'new-parens': 'error',
       // Allow/disallow an empty newline after var statement
       'newline-after-var': 'off',
       // Require newline before `return` statement
       'newline-before-return': 'off',
-      // Enforce newline after each call when chaining the calls
-      'newline-per-chained-call': ['error', {ignoreChainWithDepth: 3}],
       // Disallow use of the Array constructor
       'no-array-constructor': 'error',
       // Disallow use of the continue statement
@@ -463,14 +386,8 @@ module.exports = [
       'no-inline-comments': 'off',
       // Disallow if as the only statement in an else block
       'no-lonely-if': 'error',
-      // Disallow mixes of different operators
-      'no-mixed-operators': 'error',
-      // Disallow mixed spaces and tabs for indentation
-      'no-mixed-spaces-and-tabs': 'error',
       // Disallow use of chained assignment expressions
       'no-multi-assign': 'error',
-      // Disallow multiple empty lines
-      'no-multiple-empty-lines': 'error',
       // Disallow negated conditions
       'no-negated-condition': 'error',
       // Disallow nested ternary expressions
@@ -479,95 +396,26 @@ module.exports = [
       'no-new-object': 'error',
       // Disallow specified syntax
       'no-restricted-syntax': 'off',
-      // Disallow tabs in file
-      'no-tabs': 'error',
       // Disallow the use of ternary operators
       'no-ternary': 'off',
-      // Disallow trailing whitespace at the end of lines
-      'no-trailing-spaces': 'error',
       // Allow dangling underscores in identifiers
       'no-underscore-dangle': 'off',
       // Disallow the use of Boolean literals in conditional expressions
       'no-unneeded-ternary': 'error',
-      // Disallow whitespace before properties
-      'no-whitespace-before-property': 'error',
-      // Enforce the location of single-line statements
-      'nonblock-statement-body-position': 'off',
-      // Enforce consistent line breaks inside braces
-      'object-curly-newline': 'off',
-      // Require or disallow padding inside curly braces
-      'object-curly-spacing': ['error', 'never'],
-      // Enforce placing object properties on separate lines
-      'object-property-newline': 'off',
       // Allow or disallow one variable declaration per function
       'one-var': ['error', 'never'],
-      // Require or disallow an newline around variable declarations
-      'one-var-declaration-per-line': ['error', 'initializations'],
       // Require assignment operator shorthand where possible or prohibit it entirely
       'operator-assignment': ['error', 'always'],
-      // Enforce operators to be placed before or after line breaks
-      'operator-linebreak': [
-        'error',
-        'after',
-        {overrides: {'?': 'before', ':': 'before'}},
-      ],
-      // Enforce padding within blocks
-      'padded-blocks': 'off',
-      // require or disallow padding lines between statements
-      'padding-line-between-statements': [
-        'error',
-        {blankLine: 'always', prev: 'directive', next: '*'},
-        {blankLine: 'any', prev: 'directive', next: 'directive'},
-      ],
       // disallow using Object.assign with an object literal as the first argument and prefer the use of object spread instead.
       'prefer-object-spread': 'error',
-      // Require quotes around object literal property names
-      'quote-props': ['error', 'as-needed'],
-      // Specify whether backticks, double or single quotes should be used
-      quotes: [
-        'error',
-        'single',
-        {avoidEscape: true, allowTemplateLiterals: true},
-      ],
       // Require JSDoc comments
       'require-jsdoc': 'off',
-      // Enforce spacing before and after semicolons
-      'semi-spacing': ['error', {before: false, after: true}],
-      // enforce location of semicolons
-      'semi-style': ['error', 'last'],
-      // Require or disallow use of semicolons instead of ASI
-      semi: ['error', 'always'],
       // Requires object keys to be sorted
       'sort-keys': 'off',
       // Sort variables within the same declaration block
       'sort-vars': 'off',
-      // Require or disallow space before blocks
-      'space-before-blocks': ['error', 'always'],
-      // Require or disallow space before function opening parenthesis
-      'space-before-function-paren': [
-        'error',
-        {
-          anonymous: 'never',
-          named: 'never',
-          asyncArrow: 'always',
-        },
-      ],
-      // Require or disallow spaces inside parentheses
-      'space-in-parens': ['error', 'never'],
-      // Require spaces around operators
-      'space-infix-ops': 'error',
-      // Require or disallow spaces before/after unary operators (words on by default, nonwords)
-      'space-unary-ops': ['error', {words: true, nonwords: false}],
-      // Require or disallow a space immediately following the // or /* in a comment
-      'spaced-comment': ['error', 'always', {markers: ['=']}],
-      // enforce spacing around colons of switch statements
-      'switch-colon-spacing': ['error', {after: true, before: false}],
-      // Require or disallow spacing between template tags and their literals
-      'template-tag-spacing': ['error', 'never'],
       // Require or disallow the Unicode BOM
       'unicode-bom': ['error', 'never'],
-      // Require regex literals to be wrapped in parentheses
-      'wrap-regex': 'off',
       // Disallow the use of `Math.pow` in favor of the `**` operator
       'prefer-exponentiation-operator': 'error',
 
@@ -599,6 +447,23 @@ module.exports = [
       'no-unused-vars': 'error',
       // Disallow use of variables before they are defined
       'no-use-before-define': ['error', 'nofunc'],
+
+      //
+      // formatting rules regarding whitespace that prettier is unopinionated
+      // about but we still like
+      //
+
+      'lines-between-class-members': [
+        'error',
+        'always',
+        {exceptAfterSingleLine: true},
+      ],
+      'padding-line-between-statements': [
+        'error',
+        {blankLine: 'always', prev: 'directive', next: '*'},
+        {blankLine: 'any', prev: 'directive', next: 'directive'},
+      ],
+      'spaced-comment': ['error', 'always', {markers: ['=']}],
 
       //
       // eslint-comments

--- a/packages/eslint-plugin/lib/config/esnext.js
+++ b/packages/eslint-plugin/lib/config/esnext.js
@@ -31,18 +31,10 @@ module.exports = [
     rules: {
       // Require braces in arrow function body
       'arrow-body-style': 'off',
-      // Require parens in arrow function arguments
-      'arrow-parens': ['error', 'always'],
-      // Require space before/after arrow function's arrow
-      'arrow-spacing': ['error', {before: true, after: true}],
       // Verify super() callings in constructors
       'constructor-super': 'error',
-      // Enforce the spacing around the * in generator functions
-      'generator-star-spacing': ['error', 'after'],
       // Disallow modifying variables of class declarations
       'no-class-assign': 'error',
-      // Disallow arrow functions where they could be confused with comparisons
-      'no-confusing-arrow': ['error', {allowParens: true}],
       // Disallow modifying variables that are declared using const
       'no-const-assign': 'error',
       // Disallow duplicate name in class members
@@ -79,18 +71,12 @@ module.exports = [
       'prefer-reflect': 'off',
       // Suggest using template literals instead of strings concatenation
       'prefer-template': 'error',
-      // Enforce spacing between rest and spread operators and their expressions
-      'rest-spread-spacing': ['error', 'never'],
       // Disallow generator functions that do not have yield
       'require-yield': 'error',
       // Sort import declarations within module
       'sort-imports': 'off',
       // Require symbol descriptions
       'symbol-description': 'error',
-      // Enforce spacing around embedded expressions of template strings
-      'template-curly-spacing': ['error', 'never'],
-      // Enforce spacing around the * in yield* expressions
-      'yield-star-spacing': ['error', {before: false, after: true}],
 
       //
       // promise

--- a/packages/eslint-plugin/lib/config/prettier.js
+++ b/packages/eslint-plugin/lib/config/prettier.js
@@ -22,18 +22,4 @@ module.exports = [
       'no-unexpected-multiline': 'error',
     },
   },
-  {
-    files: ['**/*.ts', '**/*.tsx'],
-    rules: {
-      '@typescript-eslint/quotes': 'off',
-      '@typescript-eslint/brace-style': 'off',
-      '@typescript-eslint/func-call-spacing': 'off',
-      '@typescript-eslint/indent': 'off',
-      '@typescript-eslint/member-delimiter-style': 'off',
-      '@typescript-eslint/no-extra-parens': 'off',
-      '@typescript-eslint/semi': 'off',
-      '@typescript-eslint/type-annotation-spacing': 'off',
-      '@typescript-eslint/object-curly-spacing': 'off',
-    },
-  },
 ];

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -23,15 +23,6 @@ module.exports = [
     },
 
     rules: {
-      // This rule extends the base eslint/keyword-spacing rule.
-      // This version adds support for generic type parameters on function calls.
-      'keyword-spacing': 'off',
-      '@typescript-eslint/keyword-spacing': [
-        'error',
-        {before: true, after: true, overrides: {}},
-      ],
-      // Enforce one space after the colon and zero spaces before the colon of a type annotation.
-      '@typescript-eslint/type-annotation-spacing': ['error'],
       // Require explicit return types on functions and class methods
       '@typescript-eslint/explicit-function-return-type': 'off',
       // Enforce accessibility modifiers on class properties and methods. (member-access from TSLint)
@@ -94,20 +85,6 @@ module.exports = [
       '@typescript-eslint/adjacent-overload-signatures': 'error',
       // Disallow parameter properties in class constructors. (no-parameter-properties from TSLint)
       '@typescript-eslint/no-parameter-properties': 'off',
-      // Enforce a member delimiter style in interfaces and type literals.
-      '@typescript-eslint/member-delimiter-style': [
-        'error',
-        {
-          multiline: {
-            delimiter: 'semi',
-            requireLast: true,
-          },
-          singleline: {
-            delimiter: 'semi',
-            requireLast: true,
-          },
-        },
-      ],
       // Disallow the declaration of empty interfaces. (no-empty-interface from TSLint)
       '@typescript-eslint/no-empty-interface': 'off',
       // Requires using either T[] for arrays (array-type)
@@ -169,8 +146,6 @@ module.exports = [
       ],
       // Enforces naming of generic type variables
       '@typescript-eslint/generic-type-naming': 'off',
-      // Enforce consistent indentation
-      '@typescript-eslint/indent': 'off',
       // Forbids the use of classes as namespaces
       '@typescript-eslint/no-extraneous-class': [
         'error',
@@ -197,8 +172,6 @@ module.exports = [
       '@typescript-eslint/promise-function-async': 'off',
       // Bans “// @ts-ignore” comments from being used. "@ts-expect-error: some comment describing why it's disabled" is allowed
       '@typescript-eslint/ban-ts-comment': 'error',
-      // Enforce consistent brace style for blocks
-      '@typescript-eslint/brace-style': 'error',
       // Enforces consistent usage of type assertions.
       '@typescript-eslint/consistent-type-assertions': [
         'error',
@@ -206,28 +179,16 @@ module.exports = [
       ],
       // Consistent with type definition either interface or type
       '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
-      // Require or disallow spacing between function identifiers and their invocations
-      '@typescript-eslint/func-call-spacing': 'error',
       // Disallow empty functions
       '@typescript-eslint/no-empty-function': 'off',
-      // Disallow unnecessary parentheses
-      '@typescript-eslint/no-extra-parens': 'error',
       // Requires Promise-like values to be handled appropriately.
       '@typescript-eslint/no-floating-promises': 'off',
       // Disallows magic numbers
       '@typescript-eslint/no-magic-numbers': 'off',
       // Prefer a ‘for-of’ loop over a standard ‘for’ loop if the index is only used to access the array being iterated
       '@typescript-eslint/prefer-for-of': 'error',
-      // Enforce the consistent use of either backticks, double, or single quotes
-      '@typescript-eslint/quotes': [
-        'error',
-        'single',
-        {avoidEscape: true, allowTemplateLiterals: true},
-      ],
       // Enforce giving compare argument to Array#sort
       '@typescript-eslint/require-array-sort-compare': 'off',
-      // Require or disallow semicolons instead of ASI
-      '@typescript-eslint/semi': 'error',
       // Restricts the types allowed in boolean expressions
       '@typescript-eslint/strict-boolean-expressions': 'off',
       // Sets preference level for triple slash directives versus ES6-style import declarations
@@ -277,16 +238,6 @@ module.exports = [
       // Disallows unnecessary constraints on generic types
       '@typescript-eslint/no-unnecessary-type-constraint': 'error',
 
-      // Enforce consistent spacing inside braces
-      // disabling the base rule as it can report incorrect errors
-      'object-curly-spacing': 'off',
-      '@typescript-eslint/object-curly-spacing': 'error',
-
-      // This rule is aimed at ensuring there are spaces around infix operators.
-      // disabling the base rule as it can report incorrect errors
-      'space-infix-ops': 'off',
-      '@typescript-eslint/space-infix-ops': 'error',
-
       // Handled by TypeScript itself
       'no-undef': 'off',
       'no-unused-expressions': 'off',
@@ -294,15 +245,9 @@ module.exports = [
       'no-useless-constructor': 'off',
       'no-shadow': 'off',
       'no-use-before-define': 'off',
-      semi: 'off',
-      quotes: 'off',
-      indent: 'off',
-      'brace-style': 'off',
       'require-await': 'off',
       'no-magic-numbers': 'off',
-      'no-extra-parens': 'off',
       'no-empty-function': 'off',
-      'func-call-spacing': 'off',
       '@shopify/no-fully-static-classes': 'off',
       'sort-class-members/sort-class-members': 'off',
       camelcase: 'off',


### PR DESCRIPTION
## Description

Remove configuration of deprecated formatting rules.

Per https://eslint.org/blog/2023/10/deprecating-formatting-rules/ and https://typescript-eslint.io/blog/deprecating-formatting-rules several formatting related rules have been deprecated from `eslint` core and `typescript-eslint` and moved into `@stylistic/eslint-plugin`. These rules are removed in typescript-eslint v8 (released) and probably eslint v10 (unreleased).

To prepare for future updates we are removing our configuration of these rules. We recommend that you use Prettier (https://prettier.io/) for formatting considerations - either by running it in parallel with ESLint or as part of ESLint through using `eslint-plugin-prettier` via the `prettier` config provided by `@shopify/eslint-plugin`. If you do not wish to use Prettier, then we suggest you configure rules from `@stylistic/eslint-plugin` (https://eslint.style/packages/default).

Note that if you already use the `prettier` config then this removal will have no effect as all these rules were already turned off.

Configuration for the following rules in the `es5`, `esnext` and `typescript` configs have been removed:

From `typescript-eslint`:

- @typescript-eslint/brace-style
- @typescript-eslint/func-call-spacing
- @typescript-eslint/indent
- @typescript-eslint/keyword-spacing
- @typescript-eslint/member-delimiter-style
- @typescript-eslint/no-extra-parens
- @typescript-eslint/quotes
- @typescript-eslint/semi
- @typescript-eslint/space-infix-ops
- @typescript-eslint/type-annotation-spacing

From ESLint core:

- array-bracket-spacing
- arrow-parens
- arrow-spacing
- block-spacing
- brace-style
- comma-dangle
- comma-spacing
- comma-style
- computed-property-spacing
- dot-location
- eol-last
- func-call-spacing
- function-paren-newline
- generator-star-spacing
- indent-legacy
- jsx-quotes
- key-spacing
- keyword-spacing
- lines-around-comment
- lines-between-class-members
- max-statements-per-line
- new-parens
- newline-per-chained-call
- no-confusing-arrow
- no-extra-semi
- no-floating-decimal
- no-mixed-operators
- no-mixed-spaces-and-tabs
- no-multi-spaces
- no-multiple-empty-lines
- no-tabs
- no-trailing-spaces
- no-whitespace-before-property
- object-curly-spacing
- one-var-declaration-per-line
- operator-linebreak
- padding-line-between-statements
- quote-props
- quotes
- rest-spread-spacing
- semi
- semi-spacing
- semi-style
- space-before-blocks
- space-before-function-paren
- space-in-parens
- space-infix-ops
- space-unary-ops
- spaced-comment
- switch-colon-spacing
- template-curly-spacing
- template-tag-spacing
- wrap-iife
- yield-star-spacing

We retain configuration for the following rules for the moment - even though they are depreated - as prettier does not have opinions about whitespace in these cases:

- lines-between-class-members
- padding-line-between-statements
- spaced-comment