### PR TITLE
Fix prefer-module-scope-constants in commonjs files

### DIFF
--- a/.changeset/brave-rice-reflect.md
+++ b/.changeset/brave-rice-reflect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': minor
+---
+
+Fix false positives for `prefer-module-scope-constants` rule in `*.cjs` files

--- a/packages/eslint-plugin/lib/rules/prefer-module-scope-constants.js
+++ b/packages/eslint-plugin/lib/rules/prefer-module-scope-constants.js
@@ -35,7 +35,8 @@ module.exports = {
         }
 
         const scope = context.sourceCode.getScope(node);
-        if (!['module', 'global'].includes(scope.type)) {
+
+        if (!isTopScope(scope)) {
           context.report(
             node,
             'You must place screaming snake case at module scope. If this is not meant to be a module-scoped variable, use camelcase instead.',
@@ -48,3 +49,19 @@ module.exports = {
     };
   },
 };
+
+function isTopScope(scope) {
+  if (['module', 'global'].includes(scope.type)) {
+    return true;
+  }
+
+  // CommonJS does not leak values outside of a given file. ESLint handles this
+  // by claiming the whole file is wrapped in a function scope
+  if (
+    scope.upper.block.sourceType === 'commonjs' &&
+    scope.upper.type === 'global'
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/packages/eslint-plugin/tests/lib/rules/prefer-module-scope-constants.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/prefer-module-scope-constants.test.js
@@ -20,8 +20,9 @@ const nonConstErrors = [
 ];
 
 const supportedLanguageOptions = [
-  {parserOptions: {sourceType: 'module'}},
-  {parserOptions: {sourceType: 'script'}},
+  {sourceType: 'module'},
+  {sourceType: 'script'},
+  {sourceType: 'commonjs'},
 ];
 
 supportedLanguageOptions.forEach((languageOptions) => {


### PR DESCRIPTION
## Description

When using flat config, `*.cjs` files use a new sourceType "commonjs". commonjs files don't have global scope - instead each file's variables are scoped just to that file. ESLint models this scoping by making these files be wrapped in an implicit function scope.