### PR TITLE
Return no-unused-expressions linting in typescript files

### DIFF
--- a/.changeset/spicy-toes-punch.md
+++ b/.changeset/spicy-toes-punch.md
@@ -1,0 +1,7 @@
+---
+'@shopify/eslint-plugin': patch
+---
+
+Add `@typescript-eslint/no-unused-expressions` to typescript ruleset
+
+In v46 in, we enabled `no-unused-expressions` in the core js config, then disabled it and replaced it with `@babel/no-unused-expressions` in esnext config. In typescript files we turn off `no-unused-expressions` but left `@babel/no-unused-expressions` enabled - which seems like an oversight given that `@typescript-eslint/no-unused-expressions` existed. In v47.0.0 we removed configuration of `@babel/no-unused-expressions` entirely, which meant that there was no linting of unused-expressions. This change brings back unused expression linting to typescript files.

--- a/packages/eslint-plugin/lib/config/typescript.js
+++ b/packages/eslint-plugin/lib/config/typescript.js
@@ -224,6 +224,8 @@ module.exports = [
       '@typescript-eslint/consistent-indexed-object-style': 'error',
       // Disallows unnecessary constraints on generic types
       '@typescript-eslint/no-unnecessary-type-constraint': 'error',
+      // Disallow unused expressions
+      '@typescript-eslint/no-unused-expressions': 'error',
 
       // Handled by TypeScript itself
       'no-undef': 'off',


### PR DESCRIPTION
## Description

Add `@typescript-eslint/no-unused-expressions` to typescript config.

In v46:
- in the core js config we enabled `no-unused-expressions`
- in the esnext config we overrode that - disabling `no-unused-expressions` and enabling`@babel/no-unused-expressions`.
- in typescript files we disabled `no-unused-expressions to off` but left `@babel/no-unused-expressions` enabled - which seems like an oversight given that `@typescript-eslint/no-unused-expressions` existed.


In v47.0.0 we removed configuration of `@babel/no-unused-expressions` entirely, which meant that there was no linting of unused-expressions in typescript files. This change brings back unused expression linting to typescript files.