### PR TITLE
Add lint rule to disallow contextmenu listeners (right-click)

### DIFF
--- a/.changeset/calm-mirrors-fail.md
+++ b/.changeset/calm-mirrors-fail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': major
+---
+
+Add no-context-menu eslint rule

--- a/packages/eslint-plugin/docs/rules/no-context-menu.md
+++ b/packages/eslint-plugin/docs/rules/no-context-menu.md
@@ -1,0 +1,19 @@
+# Disallow contextmenu event listeners (custom right-click behavior)
+
+Overriding the browser's default right-click menu should be avoided in almost all cases. It goes against users expectations and can degrade accessibility.
+
+## Rule Details
+
+The following patterns are considered incorrect by the lint rule:
+
+```jsx
+<div onContextMenu={handler} />
+
+element.addEventListener("contextmenu", handler);
+
+useEventListener("contextmenu", handler);
+```
+
+## When not to use it
+
+If you want to override the default right click menu. This may be acceptable in rare situations, like in a full-screen web application (eg. The Online Store Theme Editor, Figma, Google Docs).

--- a/packages/eslint-plugin/lib/config/core.js
+++ b/packages/eslint-plugin/lib/config/core.js
@@ -278,6 +278,8 @@ module.exports = [
       '@shopify/jsx-prefer-fragment-wrappers': 'off',
       // Prefer that imports from within a directory extend to the file from where they are importing without relying on an index file.
       '@shopify/no-ancestor-directory-import': 'off',
+      // Disallow context-menu event listeners.
+      '@shopify/no-context-menu': 'error',
       // Disallow the use of debugger (without fixer to prevent autofix on save in editors)
       '@shopify/no-debugger': 'error',
       // Prevent namespace import declarations

--- a/packages/eslint-plugin/lib/rules/no-context-menu.js
+++ b/packages/eslint-plugin/lib/rules/no-context-menu.js
@@ -1,0 +1,55 @@
+const {docsUrl} = require('../utilities');
+
+const message =
+  'Do not override the native context menu. It almost always goes against users expectations and results in worse accessibility.';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow contextmenu event listeners',
+      category: 'Best Practices',
+      recommended: true,
+      uri: docsUrl('no-context-menu'),
+    },
+  },
+  create(context) {
+    return {
+      // Check for inline contextmenu event handlers
+      JSXAttribute(node) {
+        if (node.name.name === 'onContextMenu') {
+          context.report({
+            node,
+            message,
+          });
+        }
+      },
+
+      // Check for addEventListener('contextmenu', ...)
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          node.callee.property.name === 'addEventListener' &&
+          node.arguments?.[0]?.value === 'contextmenu'
+        ) {
+          context.report({
+            node,
+            message,
+          });
+        }
+
+        // Check for useEventListener('contextmenu', ...)
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'useEventListener' &&
+          node.arguments?.[0]?.value === 'contextmenu'
+        ) {
+          context.report({
+            node,
+            message,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/plugin.js
+++ b/packages/eslint-plugin/plugin.js
@@ -9,6 +9,7 @@ module.exports = {
     'jsx-no-hardcoded-content': require('./lib/rules/jsx-no-hardcoded-content'),
     'jsx-prefer-fragment-wrappers': require('./lib/rules/jsx-prefer-fragment-wrappers'),
     'no-ancestor-directory-import': require('./lib/rules/no-ancestor-directory-import'),
+    'no-context-menu': require('./lib/rules/no-context-menu'),
     'no-debugger': require('./lib/rules/no-debugger'),
     'no-namespace-imports': require('./lib/rules/no-namespace-imports'),
     'no-useless-computed-properties': require('./lib/rules/no-useless-computed-properties'),

--- a/packages/eslint-plugin/tests/lib/rules/no-context-menu.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/no-context-menu.test.js
@@ -1,0 +1,92 @@
+const {RuleTester} = require('eslint');
+
+const rule = require('../../../lib/rules/no-context-menu');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+
+const error = {
+  message:
+    'Do not override the native context menu. It almost always goes against users expectations and results in worse accessibility.',
+};
+
+ruleTester.run('no-context-menu', rule, {
+  valid: [
+    // Valid JSX cases
+    {code: '<div onClick={() => {}} />'},
+    {code: '<button onMouseDown={() => {}} />'},
+    {code: '<div onKeyPress={() => {}} />'},
+
+    // Valid addEventListener cases
+    {code: 'element.addEventListener("click", handler)'},
+    {code: 'element.addEventListener("mousedown", () => {})'},
+    {code: 'element.addEventListener("keypress", function() {})'},
+
+    // Valid useEventListener cases
+    {code: 'useEventListener("click", handleEvent, ref)'},
+    {code: 'useEventListener("mousedown", () => {}, element)'},
+    {code: 'useEventListener("keypress", function() {}, container)'},
+
+    // Non-addEventListener method calls
+    {code: 'element.removeEventListener("contextmenu", handler)'},
+    {code: 'otherMethod("contextmenu", handler)'},
+  ],
+
+  invalid: [
+    // Invalid JSX cases
+    {
+      code: '<div onContextMenu={() => {}} />',
+      errors: [error],
+    },
+    {
+      code: '<button onContextMenu={handleContextMenu} />',
+      errors: [error],
+    },
+    {
+      code: '<CustomComponent onContextMenu={this.handleContextMenu} />',
+      errors: [error],
+    },
+
+    // Invalid addEventListener cases
+    {
+      code: 'element.addEventListener("contextmenu", handler)',
+      errors: [error],
+    },
+    {
+      code: 'element.addEventListener("contextmenu", () => {})',
+      errors: [error],
+    },
+    {
+      code: 'element.addEventListener("contextmenu", function() {})',
+      errors: [error],
+    },
+    {
+      code: 'document.addEventListener("contextmenu", handler)',
+      errors: [error],
+    },
+    {
+      code: 'window.addEventListener("contextmenu", handler)',
+      errors: [error],
+    },
+
+    // Invalid useEventListener cases
+    {
+      code: 'useEventListener("contextmenu", handleEvent, ref)',
+      errors: [error],
+    },
+    {
+      code: 'useEventListener("contextmenu", () => {}, element)',
+      errors: [error],
+    },
+    {
+      code: 'useEventListener("contextmenu", function() {}, container)',
+      errors: [error],
+    },
+  ],
+});


### PR DESCRIPTION
## Description

Add an eslint rule to disallow `contextmenu` event listeners. Overriding the default right click menu is generally unexpected and results in worse accessibility. 

At Shopify, we believe that this should almost never been done, except in some full-screen applications, like the Online Store Theme Editor, Figma, Google Docs, etc...