### PR TITLE
Update node to v22, drop support for v18

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 18.20.0
+          node-version: 22.14.0
 
       - name: Check for Changeset
         run: npx @changesets/cli status --since="origin/main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18.x', '20.x']
+        node-version: ['20.x', '22.x']
     timeout-minutes: 10
 
     steps:

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 name: web-configs
 up:
   - node:
-      version: v18.20.0
+      version: v22.14.0
       yarn: v1.22.5
 commands:
   __default__: start


### PR DESCRIPTION
Run CI on node 20 and 22 - adding v22 and dropping support for node v18
