### PR TITLE
Remove 'should' from disallowed words list in Jest titles

### DIFF
--- a/.changeset/purple-apes-behave.md
+++ b/.changeset/purple-apes-behave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': patch
+---
+
+Removed "should" from disallowed words in `jest/valid-title` config

--- a/packages/eslint-plugin/lib/config/jest.js
+++ b/packages/eslint-plugin/lib/config/jest.js
@@ -106,7 +106,6 @@ module.exports = [
             'correct',
             'appropriate',
             'properly',
-            'should',
             'every',
             'descriptive',
           ],


### PR DESCRIPTION
## Description

<!--
Please include a summary of what you want to achieve in this pull request. Remember to add a changeset that indicates the affected package(s) and if they are major / minor / patch changes by using `pnpm exec changeset`. See https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md for more info.
-->

Removed 'should' from the list of disallowed words. I'm not sure why this was originally disallowed, but I believe it makes for nicer-looking test files. This is because affirmative and negative test cases can use the same conjugations for their verbs, whereas without "should", verbs must switch between conjugations (e.g. `___s ...` becoming `does not ___ ...` vs `should ___ ...` becoming `should not ___ ...`).

```ts
// WITHOUT
it('renders the component when the flag is enabled', () => {/* ... */});
it('does not render the component when the flag is disabled', () => {/* ... */});
it('creates a new user on submit', () => {/* ... */});
it('does not create a new user on failed submit', () => {/* ... */});

// WITH
it('should render the component when the flag is enabled', () => {/* ... */});
it('should not render the component when the flag is disabled', () => {/* ... */});
it('should create a new user on submit', () => {/* ... */});
it('should not create a new user on failed submit', () => {/* ... */});
```