### PR TITLE
Update jsx-no-hardcoded-content to handle ternary and logical expressions

### DIFF
--- a/.changeset/smooth-cows-drum.md
+++ b/.changeset/smooth-cows-drum.md
@@ -1,0 +1,5 @@
+---
+'@shopify/eslint-plugin': minor
+---
+
+extend jsx-no-hardcoded-content to handle ternary and logical expressions

--- a/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-content.js
+++ b/packages/eslint-plugin/lib/rules/jsx-no-hardcoded-content.js
@@ -205,6 +205,12 @@ function checkContent(
           !isEmptyString(contentNode.value)) ||
           (!allowNumbers && typeof contentNode.value === 'number'))) ||
       (contentNode.type === 'TemplateLiteral' && !allowStrings) ||
+      (contentNode.type === 'ConditionalExpression' &&
+        (isInvalidContent(contentNode.consequent) ||
+          isInvalidContent(contentNode.alternate))) ||
+      (contentNode.type === 'LogicalExpression' &&
+        (isInvalidContent(contentNode.left) ||
+          isInvalidContent(contentNode.right))) ||
       (contentNode.type === 'JSXExpressionContainer' &&
         isInvalidContent(contentNode.expression))
     );

--- a/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-content.test.js
+++ b/packages/eslint-plugin/tests/lib/rules/jsx-no-hardcoded-content.test.js
@@ -104,6 +104,14 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
       options: [{...checkProps, ...allowStrings}],
     },
     {
+      code: '<MyComponent>{foo ? "Content" : "Other Content"}</MyComponent>',
+      options: [{...checkProps, ...allowStrings}],
+    },
+    {
+      code: '<MyComponent>{foo && "Content"}</MyComponent>',
+      options: [{...checkProps, ...allowStrings}],
+    },
+    {
       code: '<MyComponent>{42}</MyComponent>',
       options: [
         {
@@ -425,6 +433,18 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
       code: '<MyComponent foo={`bar`} />',
       options: [checkProps],
       errors: errorsFor('MyComponent', 'foo'),
+    },
+    {
+      code: '<MyComponent>{foo ? "Content" : "Other Content"}</MyComponent>',
+      errors: errorsFor('MyComponent', 'children'),
+    },
+    {
+      code: '<MyComponent>{foo && "Content"}</MyComponent>',
+      errors: errorsFor('MyComponent', 'children'),
+    },
+    {
+      code: '<MyComponent>{foo || "Content"}</MyComponent>',
+      errors: errorsFor('MyComponent', 'children'),
     },
     {
       code: `


### PR DESCRIPTION
This PR updates the `@shopify/jsx-no-hardcoded-content` ESLint rule to detect hardcoded strings within conditional (`ternary`) and logical expressions (`&&`, `||`). Previously, expressions like the following were not flagged:

```jsx
aria-label={showPassword ? 'Hide password' : 'Show password'}
```

## Changes

- Updated `isInvalidContent` to recursively check `ConditionalExpression` and `LogicalExpression`.
